### PR TITLE
feat: Hook exec limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ coverage.html
 config.json
 redeploy.sh
 *.out
+
+OPTIMIZATION_REPORT.md

--- a/docs/en-US/Webhook-Parameters.md
+++ b/docs/en-US/Webhook-Parameters.md
@@ -43,6 +43,12 @@ Usage of webhook:
     	set the language code for the webhook (default "en-US")
   -lang-dir string
     	set the directory for the i18n files (default "./locales")
+  -hook-timeout-seconds int
+    	default timeout in seconds for hook execution (default 30)
+  -max-concurrent-hooks int
+    	maximum number of concurrent hook executions (default 10)
+  -hook-execution-timeout int
+    	timeout in seconds for acquiring execution slot when max concurrent hooks reached (default 5)
 ```
 
 Use any of the above specified flags to override their default behavior.

--- a/docs/zh-CN/CLI-ENV.md
+++ b/docs/zh-CN/CLI-ENV.md
@@ -84,6 +84,23 @@
 - `-lang-dir string`
   设置国际化文件的目录（默认值：`./locales`）
 
+### Hook 执行控制
+
+- `-hook-timeout-seconds int`
+  设置 hook 执行的默认超时时间（秒，默认值：`30`）
+  
+  当 hook 执行时间超过此值时，将被强制终止，防止长时间运行的命令占用资源。
+
+- `-max-concurrent-hooks int`
+  设置同时执行的最大 hook 数量（默认值：`10`）
+  
+  用于限制并发执行的 hook 数量，防止资源耗尽。当达到最大并发数时，新的 hook 请求将等待执行槽位。
+
+- `-hook-execution-timeout int`
+  设置获取执行槽位的超时时间（秒，默认值：`5`）
+  
+  当达到最大并发数时，新请求等待执行槽位的最大时间。超过此时间仍未获得执行机会的请求将返回错误。
+
 ### 其他
 
 - `-version`
@@ -115,6 +132,9 @@
 | `GID` | `-setgid` | 组 ID | `0` |
 | `LANGUAGE` | `-lang` | 语言代码 | `en-US` |
 | `LANG_DIR` | `-lang-dir` | 国际化文件目录 | `./locales` |
+| `HOOK_TIMEOUT_SECONDS` | `-hook-timeout-seconds` | Hook 执行超时时间（秒） | `30` |
+| `MAX_CONCURRENT_HOOKS` | `-max-concurrent-hooks` | 最大并发 hook 数量 | `10` |
+| `HOOK_EXECUTION_TIMEOUT` | `-hook-execution-timeout` | 获取执行槽位超时时间（秒） | `5` |
 
 ### 环境变量使用示例
 

--- a/internal/flags/cli.go
+++ b/internal/flags/cli.go
@@ -29,6 +29,10 @@ func ParseCLI(flags AppFlags) AppFlags {
 		Lang    = flag.String("lang", DEFAULT_LANG, "set the language code for the webhook")
 		I18nDir = flag.String("lang-dir", DEFAULT_I18N_DIR, "set the directory for the i18n files")
 
+		HookTimeoutSeconds   = flag.Int("hook-timeout-seconds", DEFAULT_HOOK_TIMEOUT_SECONDS, "default timeout in seconds for hook execution (default 30)")
+		MaxConcurrentHooks   = flag.Int("max-concurrent-hooks", DEFAULT_MAX_CONCURRENT_HOOKS, "maximum number of concurrent hook executions (default 10)")
+		HookExecutionTimeout = flag.Int("hook-execution-timeout", DEFAULT_HOOK_EXECUTION_TIMEOUT, "timeout in seconds for acquiring execution slot when max concurrent hooks reached (default 5)")
+
 		ShowVersion     = flag.Bool("version", false, "display webhook version and quit")
 		ResponseHeaders hook.ResponseHeaders
 	)
@@ -123,5 +127,18 @@ func ParseCLI(flags AppFlags) AppFlags {
 	if *I18nDir != DEFAULT_I18N_DIR {
 		flags.I18nDir = *I18nDir
 	}
+
+	if *HookTimeoutSeconds != DEFAULT_HOOK_TIMEOUT_SECONDS {
+		flags.HookTimeoutSeconds = *HookTimeoutSeconds
+	}
+
+	if *MaxConcurrentHooks != DEFAULT_MAX_CONCURRENT_HOOKS {
+		flags.MaxConcurrentHooks = *MaxConcurrentHooks
+	}
+
+	if *HookExecutionTimeout != DEFAULT_HOOK_EXECUTION_TIMEOUT {
+		flags.HookExecutionTimeout = *HookExecutionTimeout
+	}
+
 	return flags
 }

--- a/internal/flags/define.go
+++ b/internal/flags/define.go
@@ -25,6 +25,10 @@ const (
 
 	DEFAULT_LANG     = "en-US"
 	DEFAULT_I18N_DIR = "./locales"
+
+	DEFAULT_HOOK_TIMEOUT_SECONDS   = 30
+	DEFAULT_MAX_CONCURRENT_HOOKS   = 10
+	DEFAULT_HOOK_EXECUTION_TIMEOUT = 5
 )
 
 const (
@@ -50,6 +54,10 @@ const (
 
 	ENV_KEY_LANG = "LANGUAGE"
 	ENV_KEY_I18N = "LANG_DIR"
+
+	ENV_KEY_HOOK_TIMEOUT_SECONDS   = "HOOK_TIMEOUT_SECONDS"
+	ENV_KEY_MAX_CONCURRENT_HOOKS   = "MAX_CONCURRENT_HOOKS"
+	ENV_KEY_HOOK_EXECUTION_TIMEOUT = "HOOK_EXECUTION_TIMEOUT"
 )
 
 type AppFlags struct {
@@ -76,4 +84,8 @@ type AppFlags struct {
 
 	Lang    string
 	I18nDir string
+
+	HookTimeoutSeconds   int
+	MaxConcurrentHooks   int
+	HookExecutionTimeout int
 }

--- a/internal/flags/envs.go
+++ b/internal/flags/envs.go
@@ -31,6 +31,11 @@ func ParseEnvs() AppFlags {
 	flags.Lang = fn.GetEnvStr(ENV_KEY_LANG, DEFAULT_LANG)
 	flags.I18nDir = fn.GetEnvStr(ENV_KEY_I18N, DEFAULT_I18N_DIR)
 
+	// hook execution configuration
+	flags.HookTimeoutSeconds = fn.GetEnvInt(ENV_KEY_HOOK_TIMEOUT_SECONDS, DEFAULT_HOOK_TIMEOUT_SECONDS)
+	flags.MaxConcurrentHooks = fn.GetEnvInt(ENV_KEY_MAX_CONCURRENT_HOOKS, DEFAULT_MAX_CONCURRENT_HOOKS)
+	flags.HookExecutionTimeout = fn.GetEnvInt(ENV_KEY_HOOK_EXECUTION_TIMEOUT, DEFAULT_HOOK_EXECUTION_TIMEOUT)
+
 	hooks := strings.Split(fn.GetEnvStr(ENV_KEY_HOOKS, ""), ",")
 	var hooksFiles hook.HooksFiles
 	for _, hook := range hooks {

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -49,7 +49,10 @@ func WatchForFileChange(watcher *fsnotify.Watcher, asTemplate bool, verbose bool
 				}
 			}
 		case err := <-(*watcher).Errors:
-			log.Println("watcher error:", err)
+			// 只在有实际错误时才记录，nil 表示 channel 已关闭或没有错误
+			if err != nil {
+				log.Println("watcher error:", err)
+			}
 		}
 	}
 }

--- a/internal/server/executor.go
+++ b/internal/server/executor.go
@@ -1,0 +1,89 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/soulteary/webhook/internal/hook"
+)
+
+const (
+	// DefaultHookTimeout 默认 hook 执行超时时间
+	DefaultHookTimeout = 30 * time.Second
+	// DefaultMaxConcurrentHooks 默认最大并发执行的 hook 数量
+	DefaultMaxConcurrentHooks = 10
+	// HookExecutionTimeout 获取 semaphore 的超时时间
+	HookExecutionTimeout = 5 * time.Second
+)
+
+// HookExecutor 管理 hook 执行的并发控制和超时
+type HookExecutor struct {
+	sem            chan struct{}
+	maxConcurrent  int
+	defaultTimeout time.Duration
+	executorFunc   func(ctx context.Context, h *hook.Hook, r *hook.Request, w http.ResponseWriter) (string, error)
+}
+
+// NewHookExecutor 创建新的 HookExecutor 实例
+func NewHookExecutor(maxConcurrent int, defaultTimeout time.Duration) *HookExecutor {
+	if maxConcurrent <= 0 {
+		maxConcurrent = DefaultMaxConcurrentHooks
+	}
+	if defaultTimeout <= 0 {
+		defaultTimeout = DefaultHookTimeout
+	}
+	return &HookExecutor{
+		sem:            make(chan struct{}, maxConcurrent),
+		maxConcurrent:  maxConcurrent,
+		defaultTimeout: defaultTimeout,
+		executorFunc:   handleHook,
+	}
+}
+
+// NewHookExecutorWithFunc 创建新的 HookExecutor 实例，允许自定义执行函数（主要用于测试）
+func NewHookExecutorWithFunc(maxConcurrent int, defaultTimeout time.Duration, executorFunc func(ctx context.Context, h *hook.Hook, r *hook.Request, w http.ResponseWriter) (string, error)) *HookExecutor {
+	if maxConcurrent <= 0 {
+		maxConcurrent = DefaultMaxConcurrentHooks
+	}
+	if defaultTimeout <= 0 {
+		defaultTimeout = DefaultHookTimeout
+	}
+	return &HookExecutor{
+		sem:            make(chan struct{}, maxConcurrent),
+		maxConcurrent:  maxConcurrent,
+		defaultTimeout: defaultTimeout,
+		executorFunc:   executorFunc,
+	}
+}
+
+// Execute 执行 hook，带并发控制和超时
+func (he *HookExecutor) Execute(ctx context.Context, h *hook.Hook, r *hook.Request, w http.ResponseWriter, executionTimeout time.Duration) (string, error) {
+	// 尝试获取 semaphore，带超时
+	select {
+	case he.sem <- struct{}{}:
+		defer func() { <-he.sem }()
+	case <-time.After(executionTimeout):
+		return "", errors.New("too many concurrent hooks, execution timeout")
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+
+	// 创建带超时的 context
+	timeout := he.defaultTimeout
+	execCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	return he.executorFunc(execCtx, h, r, w)
+}
+
+// GetMaxConcurrent 获取最大并发数（用于测试）
+func (he *HookExecutor) GetMaxConcurrent() int {
+	return he.maxConcurrent
+}
+
+// GetDefaultTimeout 获取默认超时时间（用于测试）
+func (he *HookExecutor) GetDefaultTimeout() time.Duration {
+	return he.defaultTimeout
+}

--- a/internal/server/executor_test.go
+++ b/internal/server/executor_test.go
@@ -1,0 +1,354 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/soulteary/webhook/internal/hook"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHookExecutor_DefaultValues(t *testing.T) {
+	tests := []struct {
+		name            string
+		maxConcurrent   int
+		defaultTimeout  time.Duration
+		expectedMax     int
+		expectedTimeout time.Duration
+	}{
+		{
+			name:            "valid values",
+			maxConcurrent:   5,
+			defaultTimeout:  10 * time.Second,
+			expectedMax:     5,
+			expectedTimeout: 10 * time.Second,
+		},
+		{
+			name:            "zero max concurrent uses default",
+			maxConcurrent:   0,
+			defaultTimeout:  20 * time.Second,
+			expectedMax:     DefaultMaxConcurrentHooks,
+			expectedTimeout: 20 * time.Second,
+		},
+		{
+			name:            "negative max concurrent uses default",
+			maxConcurrent:   -1,
+			defaultTimeout:  15 * time.Second,
+			expectedMax:     DefaultMaxConcurrentHooks,
+			expectedTimeout: 15 * time.Second,
+		},
+		{
+			name:            "zero timeout uses default",
+			maxConcurrent:   3,
+			defaultTimeout:  0,
+			expectedMax:     3,
+			expectedTimeout: DefaultHookTimeout,
+		},
+		{
+			name:            "negative timeout uses default",
+			maxConcurrent:   3,
+			defaultTimeout:  -1 * time.Second,
+			expectedMax:     3,
+			expectedTimeout: DefaultHookTimeout,
+		},
+		{
+			name:            "both zero use defaults",
+			maxConcurrent:   0,
+			defaultTimeout:  0,
+			expectedMax:     DefaultMaxConcurrentHooks,
+			expectedTimeout: DefaultHookTimeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := NewHookExecutor(tt.maxConcurrent, tt.defaultTimeout)
+			assert.Equal(t, tt.expectedMax, executor.GetMaxConcurrent())
+			assert.Equal(t, tt.expectedTimeout, executor.GetDefaultTimeout())
+		})
+	}
+}
+
+func TestHookExecutor_Execute_ConcurrencyControl(t *testing.T) {
+	maxConcurrent := 2
+	executor := NewHookExecutor(maxConcurrent, 5*time.Second)
+
+	// Mock executor function that simulates work
+	var mu sync.Mutex
+	concurrentCount := 0
+	maxSeenConcurrent := 0
+
+	mockExecutorFunc := func(ctx context.Context, h *hook.Hook, r *hook.Request, w http.ResponseWriter) (string, error) {
+		mu.Lock()
+		concurrentCount++
+		if concurrentCount > maxSeenConcurrent {
+			maxSeenConcurrent = concurrentCount
+		}
+		mu.Unlock()
+
+		// Simulate some work
+		time.Sleep(50 * time.Millisecond)
+
+		mu.Lock()
+		concurrentCount--
+		mu.Unlock()
+
+		return "done", nil
+	}
+
+	executor.executorFunc = mockExecutorFunc
+
+	// Launch more goroutines than maxConcurrent
+	numGoroutines := 5
+	var wg sync.WaitGroup
+	results := make(chan string, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx := context.Background()
+			h := &hook.Hook{ID: "test"}
+			r := &hook.Request{ID: "test-request"}
+			result, err := executor.Execute(ctx, h, r, nil, 1*time.Second)
+			if err == nil {
+				results <- result
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+
+	// Verify that max concurrent executions never exceeded the limit
+	assert.LessOrEqual(t, maxSeenConcurrent, maxConcurrent, "max concurrent executions should not exceed limit")
+}
+
+func TestHookExecutor_Execute_ExecutionTimeout(t *testing.T) {
+	executor := NewHookExecutor(1, 100*time.Millisecond)
+
+	// Mock executor function that takes longer than timeout
+	mockExecutorFunc := func(ctx context.Context, h *hook.Hook, r *hook.Request, w http.ResponseWriter) (string, error) {
+		// Wait for context to be cancelled
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+
+	executor.executorFunc = mockExecutorFunc
+
+	ctx := context.Background()
+	h := &hook.Hook{ID: "test"}
+	r := &hook.Request{ID: "test-request"}
+
+	result, err := executor.Execute(ctx, h, r, nil, 1*time.Second)
+
+	// Should get timeout error
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded))
+	assert.Empty(t, result)
+}
+
+func TestHookExecutor_Execute_AcquisitionTimeout(t *testing.T) {
+	// Create executor with maxConcurrent = 1
+	executor := NewHookExecutor(1, 5*time.Second)
+
+	// Mock executor function that blocks
+	mockExecutorFunc := func(ctx context.Context, h *hook.Hook, r *hook.Request, w http.ResponseWriter) (string, error) {
+		// Block until context is cancelled
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+
+	executor.executorFunc = mockExecutorFunc
+
+	ctx := context.Background()
+	h := &hook.Hook{ID: "test"}
+	r := &hook.Request{ID: "test-request"}
+
+	// First execution should succeed (acquires semaphore)
+	go func() {
+		executor.Execute(ctx, h, r, nil, 1*time.Second)
+	}()
+
+	// Give first execution time to acquire semaphore
+	time.Sleep(10 * time.Millisecond)
+
+	// Second execution should timeout trying to acquire semaphore
+	acquisitionTimeout := 100 * time.Millisecond
+	result, err := executor.Execute(ctx, h, r, nil, acquisitionTimeout)
+
+	// Should get acquisition timeout error
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "too many concurrent hooks")
+	assert.Empty(t, result)
+}
+
+func TestHookExecutor_Execute_ContextCancellation(t *testing.T) {
+	executor := NewHookExecutor(1, 5*time.Second)
+
+	// Mock executor function that respects context
+	mockExecutorFunc := func(ctx context.Context, h *hook.Hook, r *hook.Request, w http.ResponseWriter) (string, error) {
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+
+	executor.executorFunc = mockExecutorFunc
+
+	ctx, cancel := context.WithCancel(context.Background())
+	h := &hook.Hook{ID: "test"}
+	r := &hook.Request{ID: "test-request"}
+
+	// Cancel context before execution completes
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	result, err := executor.Execute(ctx, h, r, nil, 1*time.Second)
+
+	// Should get context cancelled error
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled))
+	assert.Empty(t, result)
+}
+
+func TestHookExecutor_Execute_Success(t *testing.T) {
+	executor := NewHookExecutor(1, 5*time.Second)
+
+	expectedOutput := "test output"
+	mockExecutorFunc := func(ctx context.Context, h *hook.Hook, r *hook.Request, w http.ResponseWriter) (string, error) {
+		return expectedOutput, nil
+	}
+
+	executor.executorFunc = mockExecutorFunc
+
+	ctx := context.Background()
+	h := &hook.Hook{ID: "test"}
+	r := &hook.Request{ID: "test-request"}
+
+	result, err := executor.Execute(ctx, h, r, nil, 1*time.Second)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOutput, result)
+}
+
+func TestHookExecutor_Execute_WithResponseWriter(t *testing.T) {
+	executor := NewHookExecutor(1, 5*time.Second)
+
+	var receivedWriter http.ResponseWriter
+	mockExecutorFunc := func(ctx context.Context, h *hook.Hook, r *hook.Request, w http.ResponseWriter) (string, error) {
+		receivedWriter = w
+		return "done", nil
+	}
+
+	executor.executorFunc = mockExecutorFunc
+
+	ctx := context.Background()
+	h := &hook.Hook{ID: "test"}
+	r := &hook.Request{ID: "test-request"}
+	mockWriter := &executorMockResponseWriter{}
+
+	result, err := executor.Execute(ctx, h, r, mockWriter, 1*time.Second)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "done", result)
+	assert.Equal(t, mockWriter, receivedWriter)
+}
+
+func TestHookExecutor_Execute_MultipleConcurrent(t *testing.T) {
+	maxConcurrent := 3
+	executor := NewHookExecutor(maxConcurrent, 5*time.Second)
+
+	var wg sync.WaitGroup
+	numExecutions := 10
+	successCount := 0
+	var mu sync.Mutex
+
+	mockExecutorFunc := func(ctx context.Context, h *hook.Hook, r *hook.Request, w http.ResponseWriter) (string, error) {
+		time.Sleep(10 * time.Millisecond)
+		return "success", nil
+	}
+
+	executor.executorFunc = mockExecutorFunc
+
+	for i := 0; i < numExecutions; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			ctx := context.Background()
+			h := &hook.Hook{ID: "test"}
+			r := &hook.Request{ID: "test-request"}
+			_, err := executor.Execute(ctx, h, r, nil, 1*time.Second)
+			if err == nil {
+				mu.Lock()
+				successCount++
+				mu.Unlock()
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// All executions should succeed
+	assert.Equal(t, numExecutions, successCount)
+}
+
+func TestHookExecutor_GetMaxConcurrent(t *testing.T) {
+	executor := NewHookExecutor(5, 10*time.Second)
+	assert.Equal(t, 5, executor.GetMaxConcurrent())
+}
+
+func TestHookExecutor_GetDefaultTimeout(t *testing.T) {
+	timeout := 15 * time.Second
+	executor := NewHookExecutor(1, timeout)
+	assert.Equal(t, timeout, executor.GetDefaultTimeout())
+}
+
+// executorMockResponseWriter is a helper for testing (renamed to avoid conflict with existing mockResponseWriter)
+type executorMockResponseWriter struct {
+	header http.Header
+	code   int
+	body   []byte
+}
+
+func (m *executorMockResponseWriter) Header() http.Header {
+	if m.header == nil {
+		m.header = make(http.Header)
+	}
+	return m.header
+}
+
+func (m *executorMockResponseWriter) Write(b []byte) (int, error) {
+	m.body = append(m.body, b...)
+	return len(b), nil
+}
+
+func (m *executorMockResponseWriter) WriteHeader(code int) {
+	m.code = code
+}
+
+func TestNewHookExecutorWithFunc(t *testing.T) {
+	called := false
+	mockFunc := func(ctx context.Context, h *hook.Hook, r *hook.Request, w http.ResponseWriter) (string, error) {
+		called = true
+		return "mocked", nil
+	}
+
+	executor := NewHookExecutorWithFunc(2, 5*time.Second, mockFunc)
+	require.NotNil(t, executor)
+
+	ctx := context.Background()
+	h := &hook.Hook{ID: "test"}
+	r := &hook.Request{ID: "test-request"}
+
+	result, err := executor.Execute(ctx, h, r, nil, 1*time.Second)
+
+	assert.NoError(t, err)
+	assert.True(t, called)
+	assert.Equal(t, "mocked", result)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -436,13 +436,17 @@ func handleHook(ctx context.Context, h *hook.Hook, r *hook.Request, w http.Respo
 		if _, err := tmpfile.Write(files[i].Data); err != nil {
 			log.Printf("[%s] error writing file %s [%s]", r.ID, tmpfile.Name(), err)
 			// 如果写入失败，立即清理这个文件
-			os.Remove(tmpfile.Name())
+			if removeErr := os.Remove(tmpfile.Name()); removeErr != nil {
+				log.Printf("[%s] error removing failed temp file %s [%s]", r.ID, tmpfile.Name(), removeErr)
+			}
 			continue
 		}
 		if err := tmpfile.Close(); err != nil {
 			log.Printf("[%s] error closing file %s [%s]", r.ID, tmpfile.Name(), err)
 			// 如果关闭失败，立即清理这个文件
-			os.Remove(tmpfile.Name())
+			if removeErr := os.Remove(tmpfile.Name()); removeErr != nil {
+				log.Printf("[%s] error removing failed temp file %s [%s]", r.ID, tmpfile.Name(), removeErr)
+			}
 			continue
 		}
 

--- a/internal/server/webhook_test.go
+++ b/internal/server/webhook_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"log"
 	"mime/multipart"
@@ -58,7 +59,7 @@ func TestStaticParams(t *testing.T) {
 		ID:      "test",
 		Headers: spHeaders,
 	}
-	_, err = handleHook(spHook, r, nil)
+	_, err = handleHook(context.Background(), spHook, r, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v\n", err)
 	}
@@ -308,7 +309,7 @@ func TestHandleHook_StreamOutput(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	_, err = handleHook(h, r, w)
+	_, err = handleHook(context.Background(), h, r, w)
 	assert.NoError(t, err)
 }
 
@@ -336,7 +337,7 @@ func TestHandleHook_CaptureOutput(t *testing.T) {
 		ID: "test-request",
 	}
 
-	output, err := handleHook(h, r, nil)
+	output, err := handleHook(context.Background(), h, r, nil)
 	assert.NoError(t, err)
 	assert.Contains(t, output, "test output")
 }
@@ -364,7 +365,7 @@ func TestHandleHook_Async(t *testing.T) {
 		ID: "test-request",
 	}
 
-	output, err := handleHook(h, r, nil)
+	output, err := handleHook(context.Background(), h, r, nil)
 	assert.NoError(t, err)
 	assert.Contains(t, output, "test output")
 }
@@ -675,7 +676,7 @@ func TestHandleHook_FileCreationError(t *testing.T) {
 	}
 
 	// Test with invalid working directory (should still work but may have file creation issues)
-	output, err := handleHook(h, r, nil)
+	output, err := handleHook(context.Background(), h, r, nil)
 	// Should handle file creation errors gracefully
 	assert.NoError(t, err)
 	assert.Contains(t, output, "test output")
@@ -705,7 +706,7 @@ func TestHandleHook_CommandError(t *testing.T) {
 		ID: "test-request",
 	}
 
-	output, err := handleHook(h, r, nil)
+	output, err := handleHook(context.Background(), h, r, nil)
 	// Should return error when command fails
 	assert.Error(t, err)
 	_ = output
@@ -1055,7 +1056,7 @@ func TestHandleHook_FileOperations(t *testing.T) {
 	}
 
 	// Test file creation and cleanup
-	output, err := handleHook(h, r, nil)
+	output, err := handleHook(context.Background(), h, r, nil)
 	assert.NoError(t, err)
 	assert.Contains(t, output, "test output")
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds configurable execution limits and context-aware control for hooks, with corresponding CLI/env options and documentation.
> 
> - New `HookExecutor` with semaphore-based concurrency control and per-exec timeout; integrated into request flow
> - `handleHook` now context-aware (`exec.CommandContext`), with improved temp file cleanup and streaming response tracking
> - New CLI flags/envs: `-hook-timeout-seconds`, `-max-concurrent-hooks`, `-hook-execution-timeout` (and corresponding env vars)
> - Enhanced error handling: proper HTTP statuses for timeouts/cancellations; safer stream writes via tracking response writer
> - Extensive tests added for executor and server paths; minor watcher logging fix; docs (en/zh) updated; `.gitignore` updated
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3f90f8bd83fb92051c91834224f8a663097e51b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->