### PR TITLE
feat: add AllowAutoChmod flag for managing file permission modificati…

### DIFF
--- a/internal/flags/cli.go
+++ b/internal/flags/cli.go
@@ -32,6 +32,7 @@ func ParseCLI(flags AppFlags) AppFlags {
 		HookTimeoutSeconds   = flag.Int("hook-timeout-seconds", DEFAULT_HOOK_TIMEOUT_SECONDS, "default timeout in seconds for hook execution (default 30)")
 		MaxConcurrentHooks   = flag.Int("max-concurrent-hooks", DEFAULT_MAX_CONCURRENT_HOOKS, "maximum number of concurrent hook executions (default 10)")
 		HookExecutionTimeout = flag.Int("hook-execution-timeout", DEFAULT_HOOK_EXECUTION_TIMEOUT, "timeout in seconds for acquiring execution slot when max concurrent hooks reached (default 5)")
+		AllowAutoChmod       = flag.Bool("allow-auto-chmod", DEFAULT_ALLOW_AUTO_CHMOD, "allow automatically modifying file permissions when permission denied (SECURITY RISK: default false)")
 
 		ShowVersion     = flag.Bool("version", false, "display webhook version and quit")
 		ResponseHeaders hook.ResponseHeaders
@@ -138,6 +139,10 @@ func ParseCLI(flags AppFlags) AppFlags {
 
 	if *HookExecutionTimeout != DEFAULT_HOOK_EXECUTION_TIMEOUT {
 		flags.HookExecutionTimeout = *HookExecutionTimeout
+	}
+
+	if *AllowAutoChmod != DEFAULT_ALLOW_AUTO_CHMOD {
+		flags.AllowAutoChmod = *AllowAutoChmod
 	}
 
 	return flags

--- a/internal/flags/define.go
+++ b/internal/flags/define.go
@@ -29,6 +29,8 @@ const (
 	DEFAULT_HOOK_TIMEOUT_SECONDS   = 30
 	DEFAULT_MAX_CONCURRENT_HOOKS   = 10
 	DEFAULT_HOOK_EXECUTION_TIMEOUT = 5
+
+	DEFAULT_ALLOW_AUTO_CHMOD = false
 )
 
 const (
@@ -58,6 +60,7 @@ const (
 	ENV_KEY_HOOK_TIMEOUT_SECONDS   = "HOOK_TIMEOUT_SECONDS"
 	ENV_KEY_MAX_CONCURRENT_HOOKS   = "MAX_CONCURRENT_HOOKS"
 	ENV_KEY_HOOK_EXECUTION_TIMEOUT = "HOOK_EXECUTION_TIMEOUT"
+	ENV_KEY_ALLOW_AUTO_CHMOD       = "ALLOW_AUTO_CHMOD"
 )
 
 type AppFlags struct {
@@ -88,4 +91,5 @@ type AppFlags struct {
 	HookTimeoutSeconds   int
 	MaxConcurrentHooks   int
 	HookExecutionTimeout int
+	AllowAutoChmod       bool
 }

--- a/internal/flags/envs.go
+++ b/internal/flags/envs.go
@@ -35,6 +35,7 @@ func ParseEnvs() AppFlags {
 	flags.HookTimeoutSeconds = fn.GetEnvInt(ENV_KEY_HOOK_TIMEOUT_SECONDS, DEFAULT_HOOK_TIMEOUT_SECONDS)
 	flags.MaxConcurrentHooks = fn.GetEnvInt(ENV_KEY_MAX_CONCURRENT_HOOKS, DEFAULT_MAX_CONCURRENT_HOOKS)
 	flags.HookExecutionTimeout = fn.GetEnvInt(ENV_KEY_HOOK_EXECUTION_TIMEOUT, DEFAULT_HOOK_EXECUTION_TIMEOUT)
+	flags.AllowAutoChmod = fn.GetEnvBool(ENV_KEY_ALLOW_AUTO_CHMOD, DEFAULT_ALLOW_AUTO_CHMOD)
 
 	hooks := strings.Split(fn.GetEnvStr(ENV_KEY_HOOKS, ""), ",")
 	var hooksFiles hook.HooksFiles

--- a/internal/server/executor.go
+++ b/internal/server/executor.go
@@ -26,20 +26,10 @@ type HookExecutor struct {
 	executorFunc   func(ctx context.Context, h *hook.Hook, r *hook.Request, w http.ResponseWriter) (string, error)
 }
 
-// NewHookExecutor 创建新的 HookExecutor 实例
+// NewHookExecutor 已废弃，请使用 NewHookExecutorWithFunc
+// 此函数会 panic，因为现在 handleHook 需要 appFlags 参数
 func NewHookExecutor(maxConcurrent int, defaultTimeout time.Duration) *HookExecutor {
-	if maxConcurrent <= 0 {
-		maxConcurrent = DefaultMaxConcurrentHooks
-	}
-	if defaultTimeout <= 0 {
-		defaultTimeout = DefaultHookTimeout
-	}
-	return &HookExecutor{
-		sem:            make(chan struct{}, maxConcurrent),
-		maxConcurrent:  maxConcurrent,
-		defaultTimeout: defaultTimeout,
-		executorFunc:   handleHook,
-	}
+	panic("NewHookExecutor is deprecated. Use NewHookExecutorWithFunc instead, passing a function that wraps handleHook with appFlags")
 }
 
 // NewHookExecutorWithFunc 创建新的 HookExecutor 实例，允许自定义执行函数（主要用于测试）

--- a/internal/server/executor_test.go
+++ b/internal/server/executor_test.go
@@ -65,9 +65,14 @@ func TestNewHookExecutor_DefaultValues(t *testing.T) {
 		},
 	}
 
+	// Mock executor function for testing
+	mockExecutorFunc := func(ctx context.Context, h *hook.Hook, r *hook.Request, w http.ResponseWriter) (string, error) {
+		return "", nil
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			executor := NewHookExecutor(tt.maxConcurrent, tt.defaultTimeout)
+			executor := NewHookExecutorWithFunc(tt.maxConcurrent, tt.defaultTimeout, mockExecutorFunc)
 			assert.Equal(t, tt.expectedMax, executor.GetMaxConcurrent())
 			assert.Equal(t, tt.expectedTimeout, executor.GetDefaultTimeout())
 		})

--- a/internal/server/webhook_test.go
+++ b/internal/server/webhook_test.go
@@ -59,7 +59,8 @@ func TestStaticParams(t *testing.T) {
 		ID:      "test",
 		Headers: spHeaders,
 	}
-	_, err = handleHook(context.Background(), spHook, r, nil)
+	appFlags := flags.AppFlags{AllowAutoChmod: false}
+	_, err = handleHook(context.Background(), spHook, r, nil, appFlags)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v\n", err)
 	}
@@ -148,7 +149,8 @@ func TestMakeSureCallable(t *testing.T) {
 		ID: "test-request",
 	}
 
-	cmdPath, err := makeSureCallable(h, r)
+	appFlags := flags.AppFlags{AllowAutoChmod: false}
+	cmdPath, err := makeSureCallable(h, r, appFlags)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, cmdPath)
 }
@@ -175,7 +177,8 @@ func TestMakeSureCallable_RelativePath(t *testing.T) {
 		ID: "test-request",
 	}
 
-	cmdPath, err := makeSureCallable(h, r)
+	appFlags := flags.AppFlags{AllowAutoChmod: false}
+	cmdPath, err := makeSureCallable(h, r, appFlags)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, cmdPath)
 }
@@ -202,7 +205,8 @@ func TestMakeSureCallable_WithSpace(t *testing.T) {
 		ID: "test-request",
 	}
 
-	cmdPath, err := makeSureCallable(h, r)
+	appFlags := flags.AppFlags{AllowAutoChmod: false}
+	cmdPath, err := makeSureCallable(h, r, appFlags)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, cmdPath)
 }
@@ -309,7 +313,8 @@ func TestHandleHook_StreamOutput(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	_, err = handleHook(context.Background(), h, r, w)
+	appFlags := flags.AppFlags{AllowAutoChmod: false}
+	_, err = handleHook(context.Background(), h, r, w, appFlags)
 	assert.NoError(t, err)
 }
 
@@ -337,7 +342,8 @@ func TestHandleHook_CaptureOutput(t *testing.T) {
 		ID: "test-request",
 	}
 
-	output, err := handleHook(context.Background(), h, r, nil)
+	appFlags := flags.AppFlags{AllowAutoChmod: false}
+	output, err := handleHook(context.Background(), h, r, nil, appFlags)
 	assert.NoError(t, err)
 	assert.Contains(t, output, "test output")
 }
@@ -365,7 +371,8 @@ func TestHandleHook_Async(t *testing.T) {
 		ID: "test-request",
 	}
 
-	output, err := handleHook(context.Background(), h, r, nil)
+	appFlags := flags.AppFlags{AllowAutoChmod: false}
+	output, err := handleHook(context.Background(), h, r, nil, appFlags)
 	assert.NoError(t, err)
 	assert.Contains(t, output, "test output")
 }
@@ -596,8 +603,9 @@ func TestMakeSureCallable_PermissionDenied(t *testing.T) {
 		ID: "test-request",
 	}
 
-	// This should try to make it executable and retry
-	cmdPath, err := makeSureCallable(h, r)
+	// This should try to make it executable and retry (when AllowAutoChmod is enabled)
+	appFlags := flags.AppFlags{AllowAutoChmod: true}
+	cmdPath, err := makeSureCallable(h, r, appFlags)
 	// Should succeed after making it executable
 	assert.NoError(t, err)
 	assert.NotEmpty(t, cmdPath)
@@ -617,7 +625,8 @@ func TestMakeSureCallable_CommandNotFound(t *testing.T) {
 		ID: "test-request",
 	}
 
-	cmdPath, err := makeSureCallable(h, r)
+	appFlags := flags.AppFlags{AllowAutoChmod: false}
+	cmdPath, err := makeSureCallable(h, r, appFlags)
 	// Should return error for nonexistent command
 	assert.Error(t, err)
 	assert.Empty(t, cmdPath)
@@ -645,7 +654,8 @@ func TestMakeSureCallable_CommandWithSpace(t *testing.T) {
 		ID: "test-request",
 	}
 
-	cmdPath, err := makeSureCallable(h, r)
+	appFlags := flags.AppFlags{AllowAutoChmod: false}
+	cmdPath, err := makeSureCallable(h, r, appFlags)
 	// Should handle command with space
 	assert.NoError(t, err)
 	assert.NotEmpty(t, cmdPath)
@@ -676,7 +686,8 @@ func TestHandleHook_FileCreationError(t *testing.T) {
 	}
 
 	// Test with invalid working directory (should still work but may have file creation issues)
-	output, err := handleHook(context.Background(), h, r, nil)
+	appFlags := flags.AppFlags{AllowAutoChmod: false}
+	output, err := handleHook(context.Background(), h, r, nil, appFlags)
 	// Should handle file creation errors gracefully
 	assert.NoError(t, err)
 	assert.Contains(t, output, "test output")
@@ -706,7 +717,8 @@ func TestHandleHook_CommandError(t *testing.T) {
 		ID: "test-request",
 	}
 
-	output, err := handleHook(context.Background(), h, r, nil)
+	appFlags := flags.AppFlags{AllowAutoChmod: false}
+	output, err := handleHook(context.Background(), h, r, nil, appFlags)
 	// Should return error when command fails
 	assert.Error(t, err)
 	_ = output
@@ -1056,7 +1068,8 @@ func TestHandleHook_FileOperations(t *testing.T) {
 	}
 
 	// Test file creation and cleanup
-	output, err := handleHook(context.Background(), h, r, nil)
+	appFlags := flags.AppFlags{AllowAutoChmod: false}
+	output, err := handleHook(context.Background(), h, r, nil, appFlags)
 	assert.NoError(t, err)
 	assert.Contains(t, output, "test output")
 }
@@ -1082,8 +1095,9 @@ func TestMakeSureCallable_ChmodError(t *testing.T) {
 		ID: "test-request",
 	}
 
-	// This should try to make it executable
-	cmdPath, err := makeSureCallable(h, r)
+	// This should try to make it executable (when AllowAutoChmod is enabled)
+	appFlags := flags.AppFlags{AllowAutoChmod: true}
+	cmdPath, err := makeSureCallable(h, r, appFlags)
 	// Should succeed after making it executable
 	assert.NoError(t, err)
 	assert.NotEmpty(t, cmdPath)


### PR DESCRIPTION
…ons during hook execution

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces optional auto-chmod for hook commands and updates execution flow to receive app configuration.
> 
> - Adds `--allow-auto-chmod` CLI flag and `ALLOW_AUTO_CHMOD` env (default false) threaded through `AppFlags`
> - Updates `makeSureCallable` and `handleHook` to accept `AppFlags`; when enabled, attempts `chmod 0755` on permission denied with explicit security warnings
> - Refactors executor: deprecates `NewHookExecutor` (now panics) and adds `NewHookExecutorWithFunc` to inject a wrapper around `handleHook` that includes `appFlags`; server now uses this wrapper
> - Adjusts hook handler creation to wrap `handleHook`; maintains concurrency/timeout behavior
> - Updates tests to use the new constructor and new function signatures; adds coverage for auto-chmod enabled/disabled paths
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9697b07a45b2928b42b4b6fd8aa5e3b9a574f050. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->