### PR TITLE
feat: add MaxRequestBodySize flag and enforce request body size limit

### DIFF
--- a/internal/flags/cli.go
+++ b/internal/flags/cli.go
@@ -9,22 +9,23 @@ import (
 
 func ParseCLI(flags AppFlags) AppFlags {
 	var (
-		Host            = flag.String("ip", DEFAULT_HOST, "ip the webhook should serve hooks on")
-		Port            = flag.Int("port", DEFAULT_PORT, "port the webhook should serve hooks on")
-		Verbose         = flag.Bool("verbose", DEFAULT_ENABLE_VERBOSE, "show verbose output")
-		LogPath         = flag.String("logfile", DEFAULT_LOG_PATH, "send log output to a file; implicitly enables verbose logging")
-		Debug           = flag.Bool("debug", DEFAULT_ENABLE_DEBUG, "show debug output")
-		NoPanic         = flag.Bool("nopanic", DEFAULT_ENABLE_NO_PANIC, "do not panic if hooks cannot be loaded when webhook is not running in verbose mode")
-		HotReload       = flag.Bool("hotreload", DEFAULT_ENABLE_HOT_RELOAD, "watch hooks file for changes and reload them automatically")
-		HooksURLPrefix  = flag.String("urlprefix", DEFAULT_URL_PREFIX, "url prefix to use for served hooks (protocol://yourserver:port/PREFIX/:hook-id)")
-		AsTemplate      = flag.Bool("template", DEFAULT_ENABLE_PARSE_TEMPLATE, "parse hooks file as a Go template")
-		UseXRequestID   = flag.Bool("x-request-id", DEFAULT_ENABLE_X_REQUEST_ID, "use X-Request-Id header, if present, as request ID")
-		XRequestIDLimit = flag.Int("x-request-id-limit", DEFAULT_X_REQUEST_ID_LIMIT, "truncate X-Request-Id header to limit; default no limit")
-		MaxMultipartMem = flag.Int64("max-multipart-mem", DEFAULT_MAX_MPART_MEM, "maximum memory in bytes for parsing multipart form data before disk caching")
-		SetGID          = flag.Int("setgid", DEFAULT_GID, "set group ID after opening listening port; must be used with setuid")
-		SetUID          = flag.Int("setuid", DEFAULT_UID, "set user ID after opening listening port; must be used with setgid")
-		HttpMethods     = flag.String("http-methods", DEFAULT_HTTP_METHODS, `set default allowed HTTP methods (ie. "POST"); separate methods with comma`)
-		PidPath         = flag.String("pidfile", DEFAULT_PID_FILE, "create PID file at the given path")
+		Host               = flag.String("ip", DEFAULT_HOST, "ip the webhook should serve hooks on")
+		Port               = flag.Int("port", DEFAULT_PORT, "port the webhook should serve hooks on")
+		Verbose            = flag.Bool("verbose", DEFAULT_ENABLE_VERBOSE, "show verbose output")
+		LogPath            = flag.String("logfile", DEFAULT_LOG_PATH, "send log output to a file; implicitly enables verbose logging")
+		Debug              = flag.Bool("debug", DEFAULT_ENABLE_DEBUG, "show debug output")
+		NoPanic            = flag.Bool("nopanic", DEFAULT_ENABLE_NO_PANIC, "do not panic if hooks cannot be loaded when webhook is not running in verbose mode")
+		HotReload          = flag.Bool("hotreload", DEFAULT_ENABLE_HOT_RELOAD, "watch hooks file for changes and reload them automatically")
+		HooksURLPrefix     = flag.String("urlprefix", DEFAULT_URL_PREFIX, "url prefix to use for served hooks (protocol://yourserver:port/PREFIX/:hook-id)")
+		AsTemplate         = flag.Bool("template", DEFAULT_ENABLE_PARSE_TEMPLATE, "parse hooks file as a Go template")
+		UseXRequestID      = flag.Bool("x-request-id", DEFAULT_ENABLE_X_REQUEST_ID, "use X-Request-Id header, if present, as request ID")
+		XRequestIDLimit    = flag.Int("x-request-id-limit", DEFAULT_X_REQUEST_ID_LIMIT, "truncate X-Request-Id header to limit; default no limit")
+		MaxMultipartMem    = flag.Int64("max-multipart-mem", DEFAULT_MAX_MPART_MEM, "maximum memory in bytes for parsing multipart form data before disk caching")
+		MaxRequestBodySize = flag.Int64("max-request-body-size", DEFAULT_MAX_REQUEST_BODY_SIZE, "maximum size in bytes for request body (default 10MB)")
+		SetGID             = flag.Int("setgid", DEFAULT_GID, "set group ID after opening listening port; must be used with setuid")
+		SetUID             = flag.Int("setuid", DEFAULT_UID, "set user ID after opening listening port; must be used with setgid")
+		HttpMethods        = flag.String("http-methods", DEFAULT_HTTP_METHODS, `set default allowed HTTP methods (ie. "POST"); separate methods with comma`)
+		PidPath            = flag.String("pidfile", DEFAULT_PID_FILE, "create PID file at the given path")
 
 		Lang    = flag.String("lang", DEFAULT_LANG, "set the language code for the webhook")
 		I18nDir = flag.String("lang-dir", DEFAULT_I18N_DIR, "set the directory for the i18n files")
@@ -102,6 +103,10 @@ func ParseCLI(flags AppFlags) AppFlags {
 
 	if *MaxMultipartMem != DEFAULT_MAX_MPART_MEM {
 		flags.MaxMultipartMem = *MaxMultipartMem
+	}
+
+	if *MaxRequestBodySize != DEFAULT_MAX_REQUEST_BODY_SIZE {
+		flags.MaxRequestBodySize = *MaxRequestBodySize
 	}
 
 	if *SetGID != DEFAULT_GID {

--- a/internal/flags/define.go
+++ b/internal/flags/define.go
@@ -18,10 +18,11 @@ const (
 	DEFAULT_ENABLE_PARSE_TEMPLATE = false
 	DEFAULT_ENABLE_X_REQUEST_ID   = false
 
-	DEFAULT_X_REQUEST_ID_LIMIT = 0
-	DEFAULT_MAX_MPART_MEM      = 1 << 20
-	DEFAULT_GID                = 0
-	DEFAULT_UID                = 0
+	DEFAULT_X_REQUEST_ID_LIMIT    = 0
+	DEFAULT_MAX_MPART_MEM         = 1 << 20
+	DEFAULT_MAX_REQUEST_BODY_SIZE = 10 * 1024 * 1024 // 10MB
+	DEFAULT_GID                   = 0
+	DEFAULT_UID                   = 0
 
 	DEFAULT_LANG     = "en-US"
 	DEFAULT_I18N_DIR = "./locales"
@@ -50,16 +51,17 @@ const (
 	ENV_KEY_LOG_PATH   = "LOG_PATH"
 	ENV_KEY_HOT_RELOAD = "HOT_RELOAD"
 
-	ENV_KEY_HOOKS_URLPREFIX = "URL_PREFIX"
-	ENV_KEY_HOOKS           = "HOOKS"
-	ENV_KEY_TEMPLATE        = "TEMPLATE"
-	ENV_KEY_HTTP_METHODS    = "HTTP_METHODS"
-	ENV_KEY_PID_FILE        = "PID_FILE"
-	ENV_KEY_X_REQUEST_ID    = "X_REQUEST_ID"
-	ENV_KEY_MAX_MPART_MEM   = "MAX_MPART_MEM"
-	ENV_KEY_GID             = "GID"
-	ENV_KEY_UID             = "UID"
-	ENV_KEY_HEADER          = "HEADER"
+	ENV_KEY_HOOKS_URLPREFIX       = "URL_PREFIX"
+	ENV_KEY_HOOKS                 = "HOOKS"
+	ENV_KEY_TEMPLATE              = "TEMPLATE"
+	ENV_KEY_HTTP_METHODS          = "HTTP_METHODS"
+	ENV_KEY_PID_FILE              = "PID_FILE"
+	ENV_KEY_X_REQUEST_ID          = "X_REQUEST_ID"
+	ENV_KEY_MAX_MPART_MEM         = "MAX_MPART_MEM"
+	ENV_KEY_MAX_REQUEST_BODY_SIZE = "MAX_REQUEST_BODY_SIZE"
+	ENV_KEY_GID                   = "GID"
+	ENV_KEY_UID                   = "UID"
+	ENV_KEY_HEADER                = "HEADER"
 
 	ENV_KEY_LANG = "LANGUAGE"
 	ENV_KEY_I18N = "LANG_DIR"
@@ -78,22 +80,23 @@ const (
 )
 
 type AppFlags struct {
-	Host            string
-	Port            int
-	Verbose         bool
-	LogPath         string
-	Debug           bool
-	NoPanic         bool
-	HotReload       bool
-	HooksURLPrefix  string
-	AsTemplate      bool
-	UseXRequestID   bool
-	XRequestIDLimit int
-	MaxMultipartMem int64
-	SetGID          int
-	SetUID          int
-	HttpMethods     string
-	PidPath         string
+	Host               string
+	Port               int
+	Verbose            bool
+	LogPath            string
+	Debug              bool
+	NoPanic            bool
+	HotReload          bool
+	HooksURLPrefix     string
+	AsTemplate         bool
+	UseXRequestID      bool
+	XRequestIDLimit    int
+	MaxMultipartMem    int64
+	MaxRequestBodySize int64
+	SetGID             int
+	SetUID             int
+	HttpMethods        string
+	PidPath            string
 
 	ShowVersion     bool
 	HooksFiles      hook.HooksFiles

--- a/internal/flags/envs.go
+++ b/internal/flags/envs.go
@@ -22,6 +22,7 @@ func ParseEnvs() AppFlags {
 	flags.UseXRequestID = fn.GetEnvBool(ENV_KEY_X_REQUEST_ID, DEFAULT_ENABLE_X_REQUEST_ID)
 	flags.XRequestIDLimit = fn.GetEnvInt(ENV_KEY_X_REQUEST_ID, DEFAULT_X_REQUEST_ID_LIMIT)
 	flags.MaxMultipartMem = int64(fn.GetEnvInt(ENV_KEY_MAX_MPART_MEM, DEFAULT_MAX_MPART_MEM))
+	flags.MaxRequestBodySize = int64(fn.GetEnvInt(ENV_KEY_MAX_REQUEST_BODY_SIZE, DEFAULT_MAX_REQUEST_BODY_SIZE))
 	flags.SetGID = fn.GetEnvInt(ENV_KEY_GID, DEFAULT_GID)
 	flags.SetUID = fn.GetEnvInt(ENV_KEY_UID, DEFAULT_UID)
 	flags.HttpMethods = fn.GetEnvStr(ENV_KEY_HTTP_METHODS, DEFAULT_HTTP_METHODS)


### PR DESCRIPTION
Introduced a new MaxRequestBodySize flag to configure the maximum size of request bodies, defaulting to 10MB. Updated the CLI and environment parsing functions to support this new flag. Enhanced the createHookHandler function to enforce the request body size limit, returning appropriate errors for oversized requests. This change improves resource management and prevents potential memory exhaustion issues.