### PR TITLE
feat: add static parameters support for hooks with space in filename

### DIFF
--- a/test/hooks.json.tmpl
+++ b/test/hooks.json.tmpl
@@ -554,5 +554,18 @@
         }
       ]
     }
+  },
+  {
+    "id": "static-params-name-space",
+    "execute-command": "{{ .ScriptWithSpace }}",
+    "command-working-directory": "{{ .TempDir }}",
+    "response-message": "success",
+    "include-command-output-in-response": true,
+    "pass-arguments-to-command": [
+      {
+        "source": "string",
+        "name": "passed"
+      }
+    ]
   }
 ]

--- a/test/hooks.yaml.tmpl
+++ b/test/hooks.yaml.tmpl
@@ -314,3 +314,12 @@
           name: X-Hub-Signature
         secret: mysecret
         type: payload-hmac-sha1
+
+- id: static-params-name-space
+  execute-command: '{{ .ScriptWithSpace }}'
+  command-working-directory: '{{ .TempDir }}'
+  response-message: success
+  include-command-output-in-response: true
+  pass-arguments-to-command:
+  - source: string
+    name: passed


### PR DESCRIPTION
- Introduced a new hook configuration for handling static parameters with spaces in the filename.
- Updated the test suite to include a test case for the new hook, ensuring compatibility across different operating systems.
- Enhanced the configuration generation to accommodate the new parameters, improving flexibility in command execution.