### PR TITLE
feat: add logging configuration for request bodies

### DIFF
--- a/internal/flags/cli.go
+++ b/internal/flags/cli.go
@@ -47,6 +47,9 @@ func ParseCLI(flags AppFlags) AppFlags {
 		RateLimitRPS     = flag.Int("rate-limit-rps", DEFAULT_RATE_LIMIT_RPS, "rate limit requests per second (default 100)")
 		RateLimitBurst   = flag.Int("rate-limit-burst", DEFAULT_RATE_LIMIT_BURST, "rate limit burst size (default 10)")
 
+		// Logging flags
+		LogRequestBody = flag.Bool("log-request-body", DEFAULT_LOG_REQUEST_BODY, "log request body in debug mode (default false, SECURITY: may expose sensitive data)")
+
 		ShowVersion     = flag.Bool("version", false, "display webhook version and quit")
 		ResponseHeaders hook.ResponseHeaders
 	)
@@ -196,6 +199,11 @@ func ParseCLI(flags AppFlags) AppFlags {
 	}
 	if *RateLimitBurst != DEFAULT_RATE_LIMIT_BURST {
 		flags.RateLimitBurst = *RateLimitBurst
+	}
+
+	// Logging settings
+	if *LogRequestBody != DEFAULT_LOG_REQUEST_BODY {
+		flags.LogRequestBody = *LogRequestBody
 	}
 
 	return flags

--- a/internal/flags/define.go
+++ b/internal/flags/define.go
@@ -44,6 +44,9 @@ const (
 	DEFAULT_RATE_LIMIT_ENABLED = false
 	DEFAULT_RATE_LIMIT_RPS     = 100 // requests per second
 	DEFAULT_RATE_LIMIT_BURST   = 10  // burst size
+
+	// Logging defaults
+	DEFAULT_LOG_REQUEST_BODY = false // 默认不记录请求体，避免敏感信息泄露
 )
 
 const (
@@ -87,6 +90,9 @@ const (
 	ENV_KEY_RATE_LIMIT_ENABLED = "RATE_LIMIT_ENABLED"
 	ENV_KEY_RATE_LIMIT_RPS     = "RATE_LIMIT_RPS"
 	ENV_KEY_RATE_LIMIT_BURST   = "RATE_LIMIT_BURST"
+
+	// Logging environment keys
+	ENV_KEY_LOG_REQUEST_BODY = "LOG_REQUEST_BODY"
 )
 
 type AppFlags struct {
@@ -131,4 +137,7 @@ type AppFlags struct {
 	RateLimitEnabled bool // 是否启用限流
 	RateLimitRPS     int  // 每秒请求数限制
 	RateLimitBurst   int  // 突发请求数限制
+
+	// Logging settings
+	LogRequestBody bool // 是否在调试模式下记录请求体（默认false，避免敏感信息泄露）
 }

--- a/internal/flags/envs.go
+++ b/internal/flags/envs.go
@@ -50,6 +50,9 @@ func ParseEnvs() AppFlags {
 	flags.RateLimitRPS = fn.GetEnvInt(ENV_KEY_RATE_LIMIT_RPS, DEFAULT_RATE_LIMIT_RPS)
 	flags.RateLimitBurst = fn.GetEnvInt(ENV_KEY_RATE_LIMIT_BURST, DEFAULT_RATE_LIMIT_BURST)
 
+	// Logging settings
+	flags.LogRequestBody = fn.GetEnvBool(ENV_KEY_LOG_REQUEST_BODY, DEFAULT_LOG_REQUEST_BODY)
+
 	hooks := strings.Split(fn.GetEnvStr(ENV_KEY_HOOKS, ""), ",")
 	var hooksFiles hook.HooksFiles
 	for _, hook := range hooks {

--- a/internal/middleware/sanitizer.go
+++ b/internal/middleware/sanitizer.go
@@ -1,0 +1,338 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"regexp"
+	"strings"
+)
+
+// 敏感字段关键词列表（不区分大小写）
+var sensitiveKeywords = []string{
+	"password",
+	"passwd",
+	"pwd",
+	"secret",
+	"token",
+	"key",
+	"auth",
+	"authorization",
+	"api_key",
+	"apikey",
+	"access_token",
+	"access_token_secret",
+	"refresh_token",
+	"private_key",
+	"privatekey",
+	"credential",
+	"credentials",
+	"session",
+	"cookie",
+	"bearer",
+	"x-api-key",
+	"x-auth-token",
+}
+
+// SanitizeString 脱敏字符串中的敏感信息
+// 如果字符串包含敏感关键词，则将其替换为 "***"
+func SanitizeString(s string) string {
+	if s == "" {
+		return s
+	}
+
+	// 检查是否是键值对格式（使用 = 或 : 分隔）
+	if idx := strings.IndexAny(s, "=:"); idx > 0 {
+		key := s[:idx]
+		lowerKey := strings.ToLower(strings.TrimSpace(key))
+
+		// 检查键是否包含敏感关键词
+		for _, keyword := range sensitiveKeywords {
+			// 对于 "key" 这个通用词，只有当它是更长的敏感关键词的一部分时才脱敏
+			// 例如 "api_key" 应该脱敏，但单独的 "key" 不应该
+			if keyword == "key" {
+				// 检查是否是组合词（如 "api_key", "private_key"）
+				if lowerKey != "key" && strings.Contains(lowerKey, keyword) {
+					return key + string(s[idx]) + "***"
+				}
+			} else if strings.Contains(lowerKey, keyword) {
+				// 键包含敏感关键词，脱敏值
+				return key + string(s[idx]) + "***"
+			}
+		}
+		// 键不包含敏感关键词，返回原字符串
+		return s
+	}
+
+	// 不是键值对格式，检查整个字符串是否包含敏感关键词
+	lowerS := strings.ToLower(s)
+	for _, keyword := range sensitiveKeywords {
+		if strings.Contains(lowerS, keyword) {
+			return "***"
+		}
+	}
+
+	return s
+}
+
+// SanitizeHeader 脱敏HTTP头中的敏感信息
+func SanitizeHeader(key, value string) string {
+	lowerKey := strings.ToLower(key)
+	for _, keyword := range sensitiveKeywords {
+		if strings.Contains(lowerKey, keyword) {
+			return "***"
+		}
+	}
+	return value
+}
+
+// SanitizeJSON 脱敏JSON字符串中的敏感字段值
+func SanitizeJSON(jsonStr string) string {
+	if jsonStr == "" {
+		return jsonStr
+	}
+
+	// 尝试解析JSON
+	var jsonObj interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &jsonObj); err != nil {
+		// 如果不是有效的JSON，使用简单的字符串替换
+		return SanitizeString(jsonStr)
+	}
+
+	// 递归脱敏JSON对象
+	sanitized := sanitizeJSONValue(jsonObj)
+
+	// 重新序列化为JSON
+	result, err := json.Marshal(sanitized)
+	if err != nil {
+		// 如果序列化失败，返回脱敏后的字符串
+		return "***"
+	}
+
+	return string(result)
+}
+
+// sanitizeJSONValue 递归脱敏JSON值
+func sanitizeJSONValue(v interface{}) interface{} {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		result := make(map[string]interface{})
+		for k, v := range val {
+			lowerKey := strings.ToLower(k)
+			// 检查键是否包含敏感关键词
+			isSensitive := false
+			for _, keyword := range sensitiveKeywords {
+				if strings.Contains(lowerKey, keyword) {
+					isSensitive = true
+					break
+				}
+			}
+			if isSensitive {
+				result[k] = "***"
+			} else {
+				result[k] = sanitizeJSONValue(v)
+			}
+		}
+		return result
+	case []interface{}:
+		result := make([]interface{}, len(val))
+		for i, item := range val {
+			result[i] = sanitizeJSONValue(item)
+		}
+		return result
+	case string:
+		// 如果是字符串，检查是否包含敏感信息
+		return SanitizeString(val)
+	default:
+		return val
+	}
+}
+
+// SanitizeRequestLine 脱敏HTTP请求行
+func SanitizeRequestLine(line string) string {
+	// 请求行通常不包含敏感信息，但为了安全起见，检查URL参数
+	if strings.Contains(line, "?") {
+		parts := strings.SplitN(line, "?", 2)
+		if len(parts) == 2 {
+			// 脱敏查询参数
+			query := SanitizeQueryString(parts[1])
+			return parts[0] + "?" + query
+		}
+	}
+	return line
+}
+
+// SanitizeQueryString 脱敏查询字符串
+func SanitizeQueryString(query string) string {
+	if query == "" {
+		return query
+	}
+
+	// 解析查询参数
+	parts := strings.Split(query, "&")
+	sanitized := make([]string, 0, len(parts))
+
+	for _, part := range parts {
+		if idx := strings.Index(part, "="); idx > 0 {
+			key := part[:idx]
+			lowerKey := strings.ToLower(key)
+			// 检查键是否包含敏感关键词
+			isSensitive := false
+			for _, keyword := range sensitiveKeywords {
+				if strings.Contains(lowerKey, keyword) {
+					isSensitive = true
+					break
+				}
+			}
+			if isSensitive {
+				sanitized = append(sanitized, key+"=***")
+			} else {
+				sanitized = append(sanitized, part)
+			}
+		} else {
+			sanitized = append(sanitized, part)
+		}
+	}
+
+	return strings.Join(sanitized, "&")
+}
+
+// SanitizeRequestBody 脱敏请求体
+// contentType: Content-Type头，用于判断请求体格式
+// body: 原始请求体
+// includeBody: 是否包含请求体（如果为false，则返回空字符串）
+func SanitizeRequestBody(contentType string, body []byte, includeBody bool) string {
+	if !includeBody {
+		return ""
+	}
+
+	if len(body) == 0 {
+		return ""
+	}
+
+	bodyStr := string(body)
+
+	// 根据Content-Type选择脱敏策略
+	lowerContentType := strings.ToLower(contentType)
+	if strings.Contains(lowerContentType, "json") {
+		return SanitizeJSON(bodyStr)
+	} else if strings.Contains(lowerContentType, "x-www-form-urlencoded") {
+		return SanitizeQueryString(bodyStr)
+	} else if strings.Contains(lowerContentType, "multipart/form-data") {
+		// Multipart表单数据比较复杂，简单处理：如果包含敏感关键词则脱敏
+		return SanitizeString(bodyStr)
+	} else {
+		// 其他类型，使用通用脱敏
+		return SanitizeString(bodyStr)
+	}
+}
+
+// SanitizeDumpRequest 脱敏httputil.DumpRequest的输出
+func SanitizeDumpRequest(dump []byte, includeBody bool) []byte {
+	if len(dump) == 0 {
+		return dump
+	}
+
+	lines := bytes.Split(dump, []byte("\n"))
+	result := make([][]byte, 0, len(lines))
+	var contentType string
+	var bodyStartIdx int = -1
+
+	// 第一遍：找到Content-Type和请求体位置
+	for i, line := range lines {
+		lineStr := string(line)
+		// 查找Content-Type头
+		if strings.HasPrefix(strings.ToLower(lineStr), "content-type:") {
+			parts := strings.SplitN(lineStr, ":", 2)
+			if len(parts) == 2 {
+				contentType = strings.TrimSpace(parts[1])
+			}
+		}
+		// 查找空行（请求头和请求体的分隔符）
+		if lineStr == "" && bodyStartIdx == -1 {
+			bodyStartIdx = i + 1
+			break // 找到第一个空行即可
+		}
+	}
+
+	// 第二遍：处理每一行
+	for i, line := range lines {
+		lineStr := string(line)
+
+		// 如果已经到达请求体，根据配置决定是否处理
+		if bodyStartIdx != -1 && i >= bodyStartIdx {
+			if includeBody {
+				// 收集所有请求体行
+				bodyLines := make([]string, 0)
+				for j := bodyStartIdx; j < len(lines); j++ {
+					bodyLines = append(bodyLines, string(lines[j]))
+				}
+				bodyStr := strings.Join(bodyLines, "\n")
+				sanitizedBody := SanitizeRequestBody(contentType, []byte(bodyStr), true)
+				if sanitizedBody != "" {
+					result = append(result, []byte(sanitizedBody))
+				}
+			}
+			// 无论是否包含请求体，都停止处理
+			break
+		}
+
+		// 处理请求行
+		if i == 0 && (strings.HasPrefix(lineStr, "GET") || strings.HasPrefix(lineStr, "POST") ||
+			strings.HasPrefix(lineStr, "PUT") || strings.HasPrefix(lineStr, "DELETE") ||
+			strings.HasPrefix(lineStr, "PATCH") || strings.HasPrefix(lineStr, "HEAD") ||
+			strings.HasPrefix(lineStr, "OPTIONS")) {
+			result = append(result, []byte(SanitizeRequestLine(lineStr)))
+			continue
+		}
+
+		// 处理HTTP头
+		if strings.Contains(lineStr, ":") {
+			parts := strings.SplitN(lineStr, ":", 2)
+			if len(parts) == 2 {
+				key := strings.TrimSpace(parts[0])
+				value := strings.TrimSpace(parts[1])
+				sanitizedValue := SanitizeHeader(key, value)
+				result = append(result, []byte(key+": "+sanitizedValue))
+				continue
+			}
+		}
+
+		// 其他行（如空行）直接添加
+		result = append(result, line)
+	}
+
+	return bytes.Join(result, []byte("\n"))
+}
+
+// SanitizeError 脱敏错误消息中的敏感信息
+func SanitizeError(errMsg string) string {
+	if errMsg == "" {
+		return errMsg
+	}
+
+	// 使用正则表达式查找可能的敏感信息模式
+	patterns := []*regexp.Regexp{
+		// 匹配 password=xxx 或 password:xxx
+		regexp.MustCompile(`(?i)(password|passwd|pwd)\s*[=:]\s*[^\s,;]+`),
+		// 匹配 token=xxx 或 token:xxx
+		regexp.MustCompile(`(?i)(token|secret|key|auth)\s*[=:]\s*[^\s,;]+`),
+		// 匹配 API key 模式
+		regexp.MustCompile(`(?i)(api[_-]?key|apikey)\s*[=:]\s*[^\s,;]+`),
+		// 匹配 Bearer token
+		regexp.MustCompile(`(?i)bearer\s+[^\s,;]+`),
+	}
+
+	result := errMsg
+	for _, pattern := range patterns {
+		result = pattern.ReplaceAllStringFunc(result, func(match string) string {
+			// 提取键和值
+			parts := regexp.MustCompile(`[=:]`).Split(match, 2)
+			if len(parts) == 2 {
+				return parts[0] + "=***"
+			}
+			return "***"
+		})
+	}
+
+	return result
+}

--- a/internal/middleware/sanitizer_test.go
+++ b/internal/middleware/sanitizer_test.go
@@ -1,0 +1,253 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "普通字符串",
+			input:    "hello world",
+			expected: "hello world",
+		},
+		{
+			name:     "包含password的字符串",
+			input:    "password123",
+			expected: "***",
+		},
+		{
+			name:     "包含token的字符串",
+			input:    "token=abc123",
+			expected: "token=***",
+		},
+		{
+			name:     "键值对格式",
+			input:    "key=value",
+			expected: "key=value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizeString(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSanitizeHeader(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      string
+		value    string
+		expected string
+	}{
+		{
+			name:     "普通头",
+			key:      "Content-Type",
+			value:    "application/json",
+			expected: "application/json",
+		},
+		{
+			name:     "Authorization头",
+			key:      "Authorization",
+			value:    "Bearer token123",
+			expected: "***",
+		},
+		{
+			name:     "API-Key头",
+			key:      "X-API-Key",
+			value:    "secret123",
+			expected: "***",
+		},
+		{
+			name:     "Password头",
+			key:      "X-Password",
+			value:    "mypassword",
+			expected: "***",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizeHeader(tt.key, tt.value)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSanitizeJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "普通JSON",
+			input:    `{"name":"test","value":123}`,
+			expected: `{"name":"test","value":123}`,
+		},
+		{
+			name:     "包含password字段",
+			input:    `{"username":"user","password":"secret123"}`,
+			expected: `{"password":"***","username":"user"}`,
+		},
+		{
+			name:     "包含token字段",
+			input:    `{"token":"abc123","data":"test"}`,
+			expected: `{"data":"test","token":"***"}`,
+		},
+		{
+			name:     "嵌套JSON",
+			input:    `{"user":{"name":"test","password":"secret"}}`,
+			expected: `{"user":{"name":"test","password":"***"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizeJSON(tt.input)
+			// JSON字段顺序可能不同，所以需要特殊处理
+			if tt.name == "普通JSON" {
+				// 普通JSON不应该包含敏感信息，应该保持原样
+				assert.Contains(t, result, "test")
+				assert.Contains(t, result, "123")
+				assert.NotContains(t, result, "***")
+			} else {
+				// 包含敏感字段的JSON应该被脱敏
+				assert.Contains(t, result, "***")
+				// 验证敏感字段被脱敏
+				if tt.name == "包含password字段" {
+					assert.Contains(t, result, "password")
+					assert.Contains(t, result, "username")
+				} else if tt.name == "包含token字段" {
+					assert.Contains(t, result, "token")
+					assert.Contains(t, result, "data")
+				} else if tt.name == "嵌套JSON" {
+					assert.Contains(t, result, "user")
+					assert.Contains(t, result, "password")
+				}
+			}
+		})
+	}
+}
+
+func TestSanitizeQueryString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "普通查询字符串",
+			input:    "name=test&value=123",
+			expected: "name=test&value=123",
+		},
+		{
+			name:     "包含password参数",
+			input:    "username=user&password=secret123",
+			expected: "username=user&password=***",
+		},
+		{
+			name:     "包含token参数",
+			input:    "token=abc123&data=test",
+			expected: "token=***&data=test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizeQueryString(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSanitizeError(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "普通错误消息",
+			input:    "file not found",
+			expected: "file not found",
+		},
+		{
+			name:     "包含password的错误",
+			input:    "error: password=secret123",
+			expected: "error: password=***",
+		},
+		{
+			name:     "包含token的错误",
+			input:    "auth failed: token=abc123",
+			expected: "auth failed: token=***",
+		},
+		{
+			name:     "包含Bearer token的错误",
+			input:    "Authorization: Bearer abc123def456",
+			expected: "Authorization: ***",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizeError(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSanitizeRequestBody(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		body        []byte
+		includeBody bool
+		expected    string
+	}{
+		{
+			name:        "不包含请求体",
+			contentType: "application/json",
+			body:        []byte(`{"password":"secret"}`),
+			includeBody: false,
+			expected:    "",
+		},
+		{
+			name:        "JSON请求体",
+			contentType: "application/json",
+			body:        []byte(`{"username":"user","password":"secret"}`),
+			includeBody: true,
+			expected:    "",
+		},
+		{
+			name:        "表单请求体",
+			contentType: "application/x-www-form-urlencoded",
+			body:        []byte("username=user&password=secret"),
+			includeBody: true,
+			expected:    "username=user&password=***",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizeRequestBody(tt.contentType, tt.body, tt.includeBody)
+			if tt.name == "不包含请求体" {
+				assert.Empty(t, result)
+			} else if tt.name == "表单请求体" {
+				assert.Equal(t, tt.expected, result)
+			} else {
+				// JSON结果可能顺序不同，只检查是否包含脱敏标记
+				assert.Contains(t, result, "***")
+			}
+		})
+	}
+}

--- a/internal/server/error_handler.go
+++ b/internal/server/error_handler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/soulteary/webhook/internal/hook"
 	"github.com/soulteary/webhook/internal/logger"
+	"github.com/soulteary/webhook/internal/middleware"
 	"github.com/soulteary/webhook/internal/security"
 )
 
@@ -232,7 +233,9 @@ func logError(httpErr *HTTPError) {
 	}
 
 	if httpErr.Err != nil {
-		args = append(args, "error", httpErr.Err.Error())
+		// 脱敏错误消息中的敏感信息
+		sanitizedErrMsg := middleware.SanitizeError(httpErr.Err.Error())
+		args = append(args, "error", sanitizedErrMsg)
 	}
 
 	// 构建日志消息

--- a/internal/server/web.go
+++ b/internal/server/web.go
@@ -48,7 +48,10 @@ func Launch(appFlags flags.AppFlags, addr string, ln net.Listener) *Server {
 	}
 
 	if appFlags.Debug {
-		r.Use(middleware.Dumper(logger.Writer()))
+		dumperConfig := middleware.DumperConfig{
+			IncludeRequestBody: appFlags.LogRequestBody,
+		}
+		r.Use(middleware.DumperWithConfig(logger.Writer(), dumperConfig))
 	}
 
 	// Clean up input


### PR DESCRIPTION
- Introduced a new flag to control logging of request bodies in debug mode, enhancing security by allowing users to opt-in for detailed request logging.
- Updated environment variable and CLI flag parsing to support the new logging option.
- Enhanced the Dumper middleware to conditionally include or omit request and response bodies based on the logging configuration, ensuring sensitive information is protected.
- Sanitized error messages in the error handler to prevent exposure of sensitive data.