### PR TITLE
docs: integrate OwlMail v0.5.0 with runnable webhook demo

### DIFF
--- a/README-zhCN.md
+++ b/README-zhCN.md
@@ -155,6 +155,7 @@ http://yourserver:9000/hooks/redeploy-webhook
 - **表单数据支持**：解析 multipart 表单数据和文件上传 - 查看 [表单数据](docs/zh-CN/Referencing-Request-Values.md)
 - **模板支持**：使用 `-template` 标志在配置文件中使用 Go 模板 - 查看 [配置模版](docs/zh-CN/Templates.md)
 - **Config UI**：同一二进制，按参数切换。使用 `-config-ui` 启用配置生成 Web UI（建议仅在调试或内网使用）；与主服务共用端口（默认 `9000`），可用 `-config-ui-path` 修改路径（尾斜杠会归一化）。目录模式（默认 `./hooks` 或显式 `-hooks-dir`）下，UI 可将生成的配置直接保存到目录，保存后可立即调用生成的 URL 验证；显式 `-hooks` 单文件模式下，仍可生成/下载但不会提供目录保存。`-urlprefix` 会影响 UI 中展示的调用 URL。详见 [配置参数](docs/zh-CN/Webhook-Parameters.md) 与 [Config UI 说明](cmd/README.md)。
+- **OwlMail 联动**：接收 [OwlMail](https://github.com/soulteary/owlmail) 的签名邮件事件，验证 HMAC-SHA256、映射字段并执行受控命令。参见[联动指南](docs/zh-CN/OwlMail-Integration.md)和[可运行示例](example/owlmail/)。
 - **HTTPS**：使用反向代理（nginx、Traefik、Caddy）提供 HTTPS 支持
 - **CORS**：使用 `-header name=value` 设置自定义响应头，包括 CORS 响应头
 - **热重载**：使用 `-hotreload` 或 `kill -USR1` 无需重启即可更新配置
@@ -166,6 +167,7 @@ http://yourserver:9000/hooks/redeploy-webhook
 ### 核心文档
 - [钩子定义](docs/zh-CN/Hook-Definition.md) - 完整的钩子配置参考
 - [Config UI](cmd/README.md) - 配置生成器（运行 `go run . -config-ui` 启用）
+- [OwlMail 联动](docs/zh-CN/OwlMail-Integration.md) - 带签名的邮件事件转发与可运行 Compose 示例
 - [钩子匹配规则](docs/zh-CN/Hook-Rules.md) - 触发规则和条件
 - [配置参数](docs/zh-CN/Webhook-Parameters.md) - 命令行参数和配置
 - [配置模版](docs/zh-CN/Templates.md) - 在配置中使用 Go 模板

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ For more security options, see:
 - **Form Data Support**: Parse multipart form data and file uploads - see [Form Data](docs/en-US/Referencing-Request-Values.md)
 - **Template Support**: Use Go templates in configuration files with `-template` flag - see [Templates](docs/en-US/Templates.md)
 - **Config UI**: Same binary, behavior by flags. Enable config generator Web UI with `-config-ui` (recommend debugging or intranet only). It runs on the same server port (default `9000`) and can be mounted with `-config-ui-path` (trailing slash normalized). In directory mode (default `./hooks` or explicit `-hooks-dir`), the UI can save generated configs directly to that directory and you can validate by calling the generated endpoint immediately after save. In explicit single-file mode (`-hooks`), generation/download still works but save-to-directory is not exposed. The `-urlprefix` value is used for the call URL shown in the UI. See [Webhook Parameters](docs/en-US/Webhook-Parameters.md) and [Config UI](cmd/README.md).
+- **OwlMail integration**: Receive signed email events from [OwlMail](https://github.com/soulteary/owlmail), verify HMAC-SHA256, map fields, and run controlled commands. See the [integration guide](docs/en-US/OwlMail-Integration.md) and [runnable example](example/owlmail/).
 - **HTTPS**: Use a reverse proxy (nginx, Traefik, Caddy) for HTTPS support
 - **CORS**: Set custom headers including CORS headers with `-header name=value`
 - **Hot Reload**: Update configurations without restarting using `-hotreload` or `kill -USR1`
@@ -166,6 +167,7 @@ For more examples and use cases, check out [Hook Examples](docs/en-US/Hook-Examp
 ### Core Documentation
 - [Hook Definition](docs/en-US/Hook-Definition.md) - Complete hook configuration reference
 - [Config UI](cmd/README.md) - Config generator (enable with `go run . -config-ui`)
+- [OwlMail Integration](docs/en-US/OwlMail-Integration.md) - Signed email-event forwarding with a runnable Compose example
 - [Hook Rules](docs/en-US/Hook-Rules.md) - Trigger rules and conditions
 - [Webhook Parameters](docs/en-US/Webhook-Parameters.md) - Command-line arguments and configuration
 - [Templates](docs/en-US/Templates.md) - Using Go templates in configurations

--- a/docs/en-US/OwlMail-Integration.md
+++ b/docs/en-US/OwlMail-Integration.md
@@ -1,0 +1,160 @@
+# Integrating WebHook with OwlMail
+
+[OwlMail](https://github.com/soulteary/owlmail) can forward accepted email
+events to WebHook. WebHook authenticates the exact request body, maps selected
+JSON fields to environment variables, and runs a controlled local command.
+
+```text
+SMTP client -> OwlMail -> signed HTTP POST -> WebHook -> command/script
+```
+
+A runnable example is available in [`example/owlmail`](../../example/owlmail/).
+OwlMail also maintains the sender-side example in
+[`examples/webhooks/soulteary-webhook`](https://github.com/soulteary/owlmail/tree/main/examples/webhooks/soulteary-webhook).
+
+## Requirements
+
+- WebHook 7.0.0 or later.
+- An OwlMail build that includes webhook forwarding. The published OwlMail
+  `v0.4.0` image does not include it; build current `main` or use a later release.
+- A random shared secret of at least 32 bytes.
+- Network reachability from OwlMail to the WebHook endpoint.
+
+## 1. Configure WebHook
+
+Start from [`hooks.json.tmpl`](../../example/owlmail/hooks.json.tmpl). It defines
+`POST /hooks/owlmail`, requires `application/json`, validates
+`X-OwlMail-Signature`, and maps the payload to these variables:
+
+| JSON field | Command environment variable |
+|---|---|
+| `event` | `OWLMAIL_EVENT` |
+| `emailId` | `OWLMAIL_EMAIL_ID` |
+| `title` | `OWLMAIL_TITLE` |
+| `message` | `OWLMAIL_MESSAGE` |
+| `from` | `OWLMAIL_FROM` |
+| `to` | `OWLMAIL_TO` |
+| `receivedAt` | `OWLMAIL_RECEIVED_AT` |
+
+The configuration is a Go template so the secret and command paths stay out of
+source control:
+
+```bash
+export OWLMAIL_WEBHOOK_SECRET="$(openssl rand -hex 32)"
+export OWLMAIL_WEBHOOK_COMMAND=/opt/owlmail/handle-email.sh
+export OWLMAIL_WEBHOOK_WORKDIR=/opt/owlmail
+
+webhook \
+  -hooks hooks.json.tmpl \
+  -template \
+  -allowed-command-paths=/opt/owlmail/handle-email.sh \
+  -strict-mode
+```
+
+WebHook waits for the command because
+`include-command-output-in-response` is enabled. A command execution failure
+therefore returns a non-2xx response and allows OwlMail to retry. Command output
+is returned to OwlMail on success; do not print secrets or full message bodies
+unless that behavior is intentional.
+
+## 2. Configure OwlMail
+
+In an OwlMail build with the configurator, open `/webhooks`, create a target,
+and download `webhooks.json`. You can also start from
+[`owlmail.json`](../../example/owlmail/owlmail.json).
+
+Use these values:
+
+| Setting | Value |
+|---|---|
+| URL | `http://webhook:9000/hooks/owlmail` in Compose, or the reachable WebHook URL |
+| Method | `POST` |
+| Content type | `application/json` |
+| Secret | The same value as `OWLMAIL_WEBHOOK_SECRET` |
+| Timeout | Longer than the expected command runtime; the example uses `10s` |
+| Retries | A small bounded value; the example uses `2` |
+
+The example body template creates a stable integration payload rather than
+forwarding the entire internal email object:
+
+```json
+{
+  "event": "email.received",
+  "emailId": "...",
+  "title": "...",
+  "message": "...",
+  "from": "...",
+  "to": "...",
+  "receivedAt": "..."
+}
+```
+
+Mount the downloaded configuration and enable it with either the flag or the
+environment variable:
+
+```bash
+export OWLMAIL_WEBHOOK_URL=http://127.0.0.1:9000/hooks/owlmail
+export OWLMAIL_WEBHOOK_SECRET='replace-with-the-same-random-secret'
+owlmail -webhook-config ./owlmail.json
+```
+
+or:
+
+```bash
+export OWLMAIL_WEBHOOK_CONFIG=/app/config/owlmail.json
+```
+
+OwlMail expands environment variables before validating the configuration, so
+missing or invalid values fail startup instead of silently disabling delivery.
+
+## HMAC contract
+
+For each request, OwlMail computes HMAC-SHA256 over the exact HTTP request body
+and sends the hexadecimal digest as:
+
+```text
+X-OwlMail-Signature: sha256=<hex digest>
+```
+
+WebHook's `payload-hmac-sha256` rule verifies the same raw bytes using the shared
+secret. Do not place a proxy in the path that rewrites or decompresses the body.
+A signature mismatch returns a non-2xx response and the command is not run.
+
+## Production checklist
+
+- Keep WebHook on a private network or behind an authenticated reverse proxy.
+- Use HMAC even on a private container network; never commit the shared secret.
+- Set `-allowed-command-paths` to the exact script whenever possible.
+- Enable `-strict-mode`, bounded concurrency, execution timeouts, and rate limits.
+- Keep `-debug` and `-log-request-body` disabled for email payloads.
+- Run the command as an unprivileged user and mount scripts/configuration read-only.
+- Make handlers idempotent: OwlMail retries failed deliveries and the same email
+  event can therefore be processed more than once.
+- Keep OwlMail's timeout above the normal command duration but below the maximum
+  duration acceptable to your SMTP/event pipeline.
+
+## Filtering and multiple workflows
+
+OwlMail can filter targets by sender, recipient, subject, and text patterns. Use
+filters on the sender side when a workflow should only receive selected mail.
+Multiple OwlMail targets can call different WebHook hook IDs, for example:
+
+- `/hooks/owlmail-archive` for all messages;
+- `/hooks/owlmail-alert` for subjects matching `Critical*`;
+- `/hooks/owlmail-ticket` for messages sent to `support@example.com`.
+
+Give every endpoint its own command and, where practical, its own secret. This
+keeps permissions and failure handling isolated.
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| OwlMail fails at startup | The config path, expanded URL/secret, duration, template, and JSON syntax. |
+| WebHook returns 401/403 | Both services use the same secret and no proxy changes the body or signature header. |
+| WebHook returns 404 | The target URL ends in `/hooks/owlmail` and the hook ID is `owlmail`. |
+| OwlMail retries after 5xx | Inspect command exit status and WebHook timeout/concurrency logs. |
+| No command output in logs | Container logs do not automatically show captured stdout; use an explicit logger or a side effect appropriate to the workflow. |
+| Duplicate processing | Make the command idempotent using `OWLMAIL_EMAIL_ID` as the deduplication key. |
+
+[中文文档](../zh-CN/OwlMail-Integration.md)

--- a/docs/en-US/OwlMail-Integration.md
+++ b/docs/en-US/OwlMail-Integration.md
@@ -1,11 +1,11 @@
 # Integrating WebHook with OwlMail
 
-[OwlMail](https://github.com/soulteary/owlmail) can forward accepted email
-events to WebHook. WebHook authenticates the exact request body, maps selected
-JSON fields to environment variables, and runs a controlled local command.
+[OwlMail](https://github.com/soulteary/owlmail) can forward accepted email events
+to WebHook. WebHook authenticates the exact request body, maps selected JSON
+fields to environment variables, and runs a controlled local command.
 
 ```text
-SMTP client -> OwlMail -> signed HTTP POST -> WebHook -> command/script
+SMTP client -> OwlMail v0.5.0 -> signed HTTP POST -> WebHook -> command/script
 ```
 
 A runnable example is available in [`example/owlmail`](../../example/owlmail/).
@@ -15,29 +15,16 @@ OwlMail also maintains the sender-side example in
 ## Requirements
 
 - WebHook 7.0.0 or later.
-- An OwlMail build that includes webhook forwarding. The published OwlMail
-  `v0.4.0` image does not include it; build current `main` or use a later release.
+- OwlMail v0.5.0 or later. v0.5.0 includes webhook forwarding and the `/webhooks` configurator.
 - A random shared secret of at least 32 bytes.
 - Network reachability from OwlMail to the WebHook endpoint.
 
-## 1. Configure WebHook
+## Configure WebHook
 
 Start from [`hooks.json.tmpl`](../../example/owlmail/hooks.json.tmpl). It defines
 `POST /hooks/owlmail`, requires `application/json`, validates
-`X-OwlMail-Signature`, and maps the payload to these variables:
-
-| JSON field | Command environment variable |
-|---|---|
-| `event` | `OWLMAIL_EVENT` |
-| `emailId` | `OWLMAIL_EMAIL_ID` |
-| `title` | `OWLMAIL_TITLE` |
-| `message` | `OWLMAIL_MESSAGE` |
-| `from` | `OWLMAIL_FROM` |
-| `to` | `OWLMAIL_TO` |
-| `receivedAt` | `OWLMAIL_RECEIVED_AT` |
-
-The configuration is a Go template so the secret and command paths stay out of
-source control:
+`X-OwlMail-Signature`, and maps `event`, `emailId`, `title`, `message`, `from`,
+`to`, and `receivedAt` to fixed `OWLMAIL_*` command environment variables.
 
 ```bash
 export OWLMAIL_WEBHOOK_SECRET="$(openssl rand -hex 32)"
@@ -51,46 +38,33 @@ webhook \
   -strict-mode
 ```
 
-WebHook waits for the command because
-`include-command-output-in-response` is enabled. A command execution failure
-therefore returns a non-2xx response and allows OwlMail to retry. Command output
-is returned to OwlMail on success; do not print secrets or full message bodies
-unless that behavior is intentional.
+The example waits for command completion, so failures return non-2xx responses
+and OwlMail can retry. Keep handlers idempotent and avoid printing secrets or
+unnecessary full message bodies.
 
-## 2. Configure OwlMail
+## Configure OwlMail v0.5.0
 
-In an OwlMail build with the configurator, open `/webhooks`, create a target,
-and download `webhooks.json`. You can also start from
-[`owlmail.json`](../../example/owlmail/owlmail.json).
+Open `/webhooks` to create, import, validate, copy, and download a version 1
+configuration. Editing happens locally in the browser. Downloading does not
+activate the configuration: mount the JSON file and select it with
+`-webhook-config` or `OWLMAIL_WEBHOOK_CONFIG`.
 
-Use these values:
+The runnable demo uses the released image directly:
 
-| Setting | Value |
-|---|---|
-| URL | `http://webhook:9000/hooks/owlmail` in Compose, or the reachable WebHook URL |
-| Method | `POST` |
-| Content type | `application/json` |
-| Secret | The same value as `OWLMAIL_WEBHOOK_SECRET` |
-| Timeout | Longer than the expected command runtime; the example uses `10s` |
-| Retries | A small bounded value; the example uses `2` |
-
-The example body template creates a stable integration payload rather than
-forwarding the entire internal email object:
-
-```json
-{
-  "event": "email.received",
-  "emailId": "...",
-  "title": "...",
-  "message": "...",
-  "from": "...",
-  "to": "...",
-  "receivedAt": "..."
-}
+```yaml
+owlmail:
+  image: soulteary/owlmail:0.5.0
+  environment:
+    OWLMAIL_WEBHOOK_CONFIG: /app/config/owlmail.json
+    OWLMAIL_WEBHOOK_MAX_CONCURRENCY: "8"
 ```
 
-Mount the downloaded configuration and enable it with either the flag or the
-environment variable:
+OwlMail's process-wide webhook concurrency limit defaults to `8`. Set
+`OWLMAIL_WEBHOOK_MAX_CONCURRENCY=0` only when unlimited delivery is intentional.
+
+For the demo, use `http://webhook:9000/hooks/owlmail`, `POST`, JSON content, the
+same shared secret on both services, a timeout above normal command duration,
+and a small bounded retry count. The checked-in example uses `10s` and `2` retries.
 
 ```bash
 export OWLMAIL_WEBHOOK_URL=http://127.0.0.1:9000/hooks/owlmail
@@ -98,63 +72,57 @@ export OWLMAIL_WEBHOOK_SECRET='replace-with-the-same-random-secret'
 owlmail -webhook-config ./owlmail.json
 ```
 
-or:
-
-```bash
-export OWLMAIL_WEBHOOK_CONFIG=/app/config/owlmail.json
-```
-
-OwlMail expands environment variables before validating the configuration, so
-missing or invalid values fail startup instead of silently disabling delivery.
+OwlMail expands environment variables before validation. Missing or invalid
+runtime values fail startup instead of silently disabling delivery.
 
 ## HMAC contract
 
-For each request, OwlMail computes HMAC-SHA256 over the exact HTTP request body
-and sends the hexadecimal digest as:
+OwlMail computes HMAC-SHA256 over the exact HTTP request body and sends:
 
 ```text
 X-OwlMail-Signature: sha256=<hex digest>
 ```
 
-WebHook's `payload-hmac-sha256` rule verifies the same raw bytes using the shared
-secret. Do not place a proxy in the path that rewrites or decompresses the body.
-A signature mismatch returns a non-2xx response and the command is not run.
+WebHook's `payload-hmac-sha256` rule verifies the same raw bytes. A proxy must not
+rewrite the request body; a signature mismatch prevents command execution.
+
+## One-command demo
+
+```bash
+cd example/owlmail
+export OWLMAIL_WEBHOOK_SECRET="$(openssl rand -hex 32)"
+docker compose up
+```
+
+Send a test message to `smtp://127.0.0.1:1025`. Open
+`http://127.0.0.1:1080` for the inbox and `http://127.0.0.1:1080/webhooks` for
+the v0.5.0 webhook configurator. The WebHook container logs the verified and
+mapped demo event.
 
 ## Production checklist
 
-- Keep WebHook on a private network or behind an authenticated reverse proxy.
-- Use HMAC even on a private container network; never commit the shared secret.
-- Set `-allowed-command-paths` to the exact script whenever possible.
-- Enable `-strict-mode`, bounded concurrency, execution timeouts, and rate limits.
-- Keep `-debug` and `-log-request-body` disabled for email payloads.
-- Run the command as an unprivileged user and mount scripts/configuration read-only.
-- Make handlers idempotent: OwlMail retries failed deliveries and the same email
-  event can therefore be processed more than once.
-- Keep OwlMail's timeout above the normal command duration but below the maximum
-  duration acceptable to your SMTP/event pipeline.
+- Keep WebHook private or behind an authenticated reverse proxy and retain HMAC.
+- Restrict `-allowed-command-paths`; enable strict mode, bounded concurrency, execution timeouts, and rate limits.
+- Keep OwlMail at the default concurrency of `8` or size it to downstream capacity; do not accidentally set it to `0`.
+- Keep raw request-body logging disabled for email payloads and run commands unprivileged.
+- Use `OWLMAIL_EMAIL_ID` as a deduplication key so retries are safe.
+- Keep OwlMail's timeout above normal command duration but bounded for the event pipeline.
 
 ## Filtering and multiple workflows
 
-OwlMail can filter targets by sender, recipient, subject, and text patterns. Use
-filters on the sender side when a workflow should only receive selected mail.
-Multiple OwlMail targets can call different WebHook hook IDs, for example:
-
-- `/hooks/owlmail-archive` for all messages;
-- `/hooks/owlmail-alert` for subjects matching `Critical*`;
-- `/hooks/owlmail-ticket` for messages sent to `support@example.com`.
-
-Give every endpoint its own command and, where practical, its own secret. This
-keeps permissions and failure handling isolated.
+OwlMail v0.5.0 supports case-insensitive wildcard filters for sender, recipient,
+and subject. Multiple targets can call separate hook IDs such as
+`/hooks/owlmail-archive`, `/hooks/owlmail-alert`, and `/hooks/owlmail-ticket`.
+Use separate commands and, where practical, separate secrets to isolate permissions.
 
 ## Troubleshooting
 
 | Symptom | Check |
 |---|---|
-| OwlMail fails at startup | The config path, expanded URL/secret, duration, template, and JSON syntax. |
+| OwlMail fails at startup | Config path, expanded URL/secret, duration, template, and JSON syntax. |
 | WebHook returns 401/403 | Both services use the same secret and no proxy changes the body or signature header. |
 | WebHook returns 404 | The target URL ends in `/hooks/owlmail` and the hook ID is `owlmail`. |
 | OwlMail retries after 5xx | Inspect command exit status and WebHook timeout/concurrency logs. |
-| No command output in logs | Container logs do not automatically show captured stdout; use an explicit logger or a side effect appropriate to the workflow. |
-| Duplicate processing | Make the command idempotent using `OWLMAIL_EMAIL_ID` as the deduplication key. |
+| Duplicate processing | Make the command idempotent using `OWLMAIL_EMAIL_ID`. |
 
 [中文文档](../zh-CN/OwlMail-Integration.md)

--- a/docs/zh-CN/OwlMail-Integration.md
+++ b/docs/zh-CN/OwlMail-Integration.md
@@ -5,38 +5,25 @@ WebHook。WebHook 对完整请求体进行鉴权，将指定 JSON 字段映射�
 受控的本地命令。
 
 ```text
-SMTP 客户端 -> OwlMail -> 带签名的 HTTP POST -> WebHook -> 命令/脚本
+SMTP 客户端 -> OwlMail v0.5.0 -> 带签名的 HTTP POST -> WebHook -> 命令/脚本
 ```
 
 可运行示例位于 [`example/owlmail`](../../example/owlmail/)。OwlMail 仓库也维护了
-发送端示例：
-[`examples/webhooks/soulteary-webhook`](https://github.com/soulteary/owlmail/tree/main/examples/webhooks/soulteary-webhook)。
+发送端示例：[`examples/webhooks/soulteary-webhook`](https://github.com/soulteary/owlmail/tree/main/examples/webhooks/soulteary-webhook)。
 
 ## 使用要求
 
 - WebHook 7.0.0 或更高版本。
-- 包含 Webhook 转发功能的 OwlMail。目前已发布的 OwlMail `v0.4.0` 镜像尚不
-  包含该功能，需要构建当前 `main`，或使用后续版本。
+- OwlMail v0.5.0 或更高版本；v0.5.0 已正式包含 Webhook 转发与 `/webhooks` 配置生成器。
 - 至少 32 字节的随机共享密钥。
 - OwlMail 能够访问 WebHook 端点。
 
 ## 1. 配置 WebHook
 
 可以从 [`hooks.json.tmpl`](../../example/owlmail/hooks.json.tmpl) 开始。它定义了
-`POST /hooks/owlmail`，要求 `application/json`，验证
-`X-OwlMail-Signature`，并进行以下字段映射：
-
-| JSON 字段 | 命令环境变量 |
-|---|---|
-| `event` | `OWLMAIL_EVENT` |
-| `emailId` | `OWLMAIL_EMAIL_ID` |
-| `title` | `OWLMAIL_TITLE` |
-| `message` | `OWLMAIL_MESSAGE` |
-| `from` | `OWLMAIL_FROM` |
-| `to` | `OWLMAIL_TO` |
-| `receivedAt` | `OWLMAIL_RECEIVED_AT` |
-
-该配置使用 Go 模板，使密钥和命令路径不进入版本库：
+`POST /hooks/owlmail`，要求 `application/json`，验证 `X-OwlMail-Signature`，并将
+`event`、`emailId`、`title`、`message`、`from`、`to`、`receivedAt` 映射到固定的
+`OWLMAIL_*` 环境变量。
 
 ```bash
 export OWLMAIL_WEBHOOK_SECRET="$(openssl rand -hex 32)"
@@ -50,42 +37,33 @@ webhook \
   -strict-mode
 ```
 
-示例启用了 `include-command-output-in-response`，WebHook 会等待命令结束；命令
-执行失败会返回非 2xx，让 OwlMail 按策略重试。成功时命令输出会返回给 OwlMail，
-因此脚本不应输出密钥或完整邮件内容，除非这是明确需要的行为。
+示例启用了 `include-command-output-in-response`，命令失败会返回非 2xx，使 OwlMail
+按策略重试。处理脚本应保持幂等，并避免输出密钥或不必要的完整邮件正文。
 
-## 2. 配置 OwlMail
+## 2. 配置 OwlMail v0.5.0
 
-在包含配置页面的 OwlMail 构建中，打开 `/webhooks`，创建目标并下载
-`webhooks.json`；也可以直接从
-[`owlmail.json`](../../example/owlmail/owlmail.json) 修改。
+打开 OwlMail 的 `/webhooks` 页面，可以创建、导入、校验、复制和下载 version 1
+配置。编辑过程发生在浏览器本地；下载配置并不会自动激活它，需要把 JSON 文件挂载
+到 OwlMail 并通过 `-webhook-config` 或 `OWLMAIL_WEBHOOK_CONFIG` 指定。
 
-建议配置如下：
+Compose 示例直接使用发布镜像：
 
-| 配置项 | 数值 |
-|---|---|
-| URL | Compose 中使用 `http://webhook:9000/hooks/owlmail`，其他环境填写 WebHook 可达地址 |
-| 方法 | `POST` |
-| Content-Type | `application/json` |
-| 密钥 | 与 `OWLMAIL_WEBHOOK_SECRET` 完全相同 |
-| 超时 | 大于命令正常耗时；示例为 `10s` |
-| 重试 | 使用较小的有界值；示例为 `2` |
-
-示例请求体模板只发送联动所需字段，不会直接转发完整的内部邮件对象：
-
-```json
-{
-  "event": "email.received",
-  "emailId": "...",
-  "title": "...",
-  "message": "...",
-  "from": "...",
-  "to": "...",
-  "receivedAt": "..."
-}
+```yaml
+owlmail:
+  image: soulteary/owlmail:0.5.0
+  environment:
+    OWLMAIL_WEBHOOK_CONFIG: /app/config/owlmail.json
+    OWLMAIL_WEBHOOK_MAX_CONCURRENCY: "8"
 ```
 
-挂载下载的配置文件，并通过参数或环境变量启用：
+`OWLMAIL_WEBHOOK_MAX_CONCURRENCY` 默认值为 `8`，用于限制进程级 Webhook 并发投递；
+只有明确希望不限制并发时才设置为 `0`。
+
+建议目标配置：URL 使用 `http://webhook:9000/hooks/owlmail`，方法 `POST`，内容类型
+`application/json`，共享密钥与 WebHook 一致，超时略高于正常命令耗时，重试次数保持
+较小且有界。示例使用 `10s` 超时和 `2` 次重试。
+
+运行时可以这样启用：
 
 ```bash
 export OWLMAIL_WEBHOOK_URL=http://127.0.0.1:9000/hooks/owlmail
@@ -93,48 +71,46 @@ export OWLMAIL_WEBHOOK_SECRET='替换为两边一致的随机密钥'
 owlmail -webhook-config ./owlmail.json
 ```
 
-或者：
-
-```bash
-export OWLMAIL_WEBHOOK_CONFIG=/app/config/owlmail.json
-```
-
-OwlMail 会先展开环境变量，再验证配置；缺少变量或数值无效时会启动失败，不会
-静默关闭消息投递。
+OwlMail 会先展开环境变量，再验证配置；缺少变量或数值无效时启动失败，不会静默关闭
+消息投递。
 
 ## HMAC 约定
 
-OwlMail 对每次 HTTP 请求的原始请求体计算 HMAC-SHA256，并发送十六进制摘要：
+OwlMail 对每次 HTTP 请求的原始请求体计算 HMAC-SHA256：
 
 ```text
 X-OwlMail-Signature: sha256=<十六进制摘要>
 ```
 
-WebHook 的 `payload-hmac-sha256` 规则使用同一密钥校验完全相同的原始字节。链路
-中的代理不能改写或重新压缩请求体。签名不匹配时，WebHook 返回非 2xx 且不执行
-命令。
+WebHook 的 `payload-hmac-sha256` 规则使用同一密钥验证原始字节。代理不能改写请求体；
+签名不匹配时不执行命令。
+
+## 一键 Demo
+
+```bash
+cd example/owlmail
+export OWLMAIL_WEBHOOK_SECRET="$(openssl rand -hex 32)"
+docker compose up
+```
+
+随后通过 `curl smtp://127.0.0.1:1025` 发送测试邮件。访问 `http://127.0.0.1:1080`
+查看邮件，访问 `http://127.0.0.1:1080/webhooks` 查看 v0.5.0 的 Webhook 配置生成器，
+WebHook 容器日志中可以看到经过签名校验和字段映射后的 Demo 输出。
 
 ## 生产环境检查清单
 
-- 将 WebHook 放在私有网络，或置于带身份认证的反向代理之后。
-- 即使使用容器私有网络也保留 HMAC；不要把共享密钥提交到仓库。
-- 尽量让 `-allowed-command-paths` 只包含明确的脚本路径。
-- 启用 `-strict-mode`、有界并发、执行超时与速率限制。
-- 邮件请求不要启用 `-debug` 和 `-log-request-body`。
-- 使用非特权用户运行命令，并以只读方式挂载脚本和配置。
-- 处理脚本必须幂等：OwlMail 会重试失败投递，同一邮件事件可能被处理多次。
-- OwlMail 超时应高于命令正常耗时，但不能无限延长 SMTP/事件链路等待时间。
+- WebHook 放在私有网络或带认证的反向代理之后，并保留 HMAC。
+- `-allowed-command-paths` 只允许明确脚本，启用 `-strict-mode`、并发限制、执行超时和限流。
+- OwlMail 保持默认 `8` 或按下游容量设置 `OWLMAIL_WEBHOOK_MAX_CONCURRENCY`，不要无意设置为 `0`。
+- 邮件链路不要开启原始请求体日志；命令使用非特权用户执行。
+- 使用 `OWLMAIL_EMAIL_ID` 作为去重键，使重试安全。
+- OwlMail 超时应高于命令正常耗时，但不要无限延长事件链路等待时间。
 
 ## 过滤与多工作流
 
-OwlMail 可以按发件人、收件人、主题和正文模式过滤目标。只需要处理部分邮件时，
-优先在发送端过滤。多个 OwlMail 目标可以调用不同 Hook ID，例如：
-
-- `/hooks/owlmail-archive`：处理全部邮件；
-- `/hooks/owlmail-alert`：仅处理主题匹配 `Critical*` 的邮件；
-- `/hooks/owlmail-ticket`：仅处理发送到 `support@example.com` 的邮件。
-
-每个端点应使用独立命令；条件允许时也使用独立密钥，以隔离权限和失败处理。
+OwlMail v0.5.0 支持按发件人、收件人和主题进行大小写不敏感的通配符过滤。多个目标可
+分别调用 `/hooks/owlmail-archive`、`/hooks/owlmail-alert`、`/hooks/owlmail-ticket`
+等 Hook，并使用独立命令和密钥隔离权限与失败处理。
 
 ## 故障排查
 
@@ -144,7 +120,6 @@ OwlMail 可以按发件人、收件人、主题和正文模式过滤目标。只
 | WebHook 返回 401/403 | 两边密钥是否一致，代理是否修改请求体或签名头。 |
 | WebHook 返回 404 | 目标 URL 是否以 `/hooks/owlmail` 结尾，Hook ID 是否为 `owlmail`。 |
 | OwlMail 遇到 5xx 后重试 | 检查命令退出状态、WebHook 超时及并发日志。 |
-| 日志里没有命令输出 | 捕获的 stdout 不一定自动进入容器日志；根据工作流显式记录日志或执行副作用。 |
 | 同一事件重复处理 | 使用 `OWLMAIL_EMAIL_ID` 作为去重键，让命令保持幂等。 |
 
 [English](../en-US/OwlMail-Integration.md)

--- a/docs/zh-CN/OwlMail-Integration.md
+++ b/docs/zh-CN/OwlMail-Integration.md
@@ -1,0 +1,150 @@
+# WebHook 与 OwlMail 联动
+
+[OwlMail](https://github.com/soulteary/owlmail) 可以把接收邮件事件转发给
+WebHook。WebHook 对完整请求体进行鉴权，将指定 JSON 字段映射为环境变量，再执行
+受控的本地命令。
+
+```text
+SMTP 客户端 -> OwlMail -> 带签名的 HTTP POST -> WebHook -> 命令/脚本
+```
+
+可运行示例位于 [`example/owlmail`](../../example/owlmail/)。OwlMail 仓库也维护了
+发送端示例：
+[`examples/webhooks/soulteary-webhook`](https://github.com/soulteary/owlmail/tree/main/examples/webhooks/soulteary-webhook)。
+
+## 使用要求
+
+- WebHook 7.0.0 或更高版本。
+- 包含 Webhook 转发功能的 OwlMail。目前已发布的 OwlMail `v0.4.0` 镜像尚不
+  包含该功能，需要构建当前 `main`，或使用后续版本。
+- 至少 32 字节的随机共享密钥。
+- OwlMail 能够访问 WebHook 端点。
+
+## 1. 配置 WebHook
+
+可以从 [`hooks.json.tmpl`](../../example/owlmail/hooks.json.tmpl) 开始。它定义了
+`POST /hooks/owlmail`，要求 `application/json`，验证
+`X-OwlMail-Signature`，并进行以下字段映射：
+
+| JSON 字段 | 命令环境变量 |
+|---|---|
+| `event` | `OWLMAIL_EVENT` |
+| `emailId` | `OWLMAIL_EMAIL_ID` |
+| `title` | `OWLMAIL_TITLE` |
+| `message` | `OWLMAIL_MESSAGE` |
+| `from` | `OWLMAIL_FROM` |
+| `to` | `OWLMAIL_TO` |
+| `receivedAt` | `OWLMAIL_RECEIVED_AT` |
+
+该配置使用 Go 模板，使密钥和命令路径不进入版本库：
+
+```bash
+export OWLMAIL_WEBHOOK_SECRET="$(openssl rand -hex 32)"
+export OWLMAIL_WEBHOOK_COMMAND=/opt/owlmail/handle-email.sh
+export OWLMAIL_WEBHOOK_WORKDIR=/opt/owlmail
+
+webhook \
+  -hooks hooks.json.tmpl \
+  -template \
+  -allowed-command-paths=/opt/owlmail/handle-email.sh \
+  -strict-mode
+```
+
+示例启用了 `include-command-output-in-response`，WebHook 会等待命令结束；命令
+执行失败会返回非 2xx，让 OwlMail 按策略重试。成功时命令输出会返回给 OwlMail，
+因此脚本不应输出密钥或完整邮件内容，除非这是明确需要的行为。
+
+## 2. 配置 OwlMail
+
+在包含配置页面的 OwlMail 构建中，打开 `/webhooks`，创建目标并下载
+`webhooks.json`；也可以直接从
+[`owlmail.json`](../../example/owlmail/owlmail.json) 修改。
+
+建议配置如下：
+
+| 配置项 | 数值 |
+|---|---|
+| URL | Compose 中使用 `http://webhook:9000/hooks/owlmail`，其他环境填写 WebHook 可达地址 |
+| 方法 | `POST` |
+| Content-Type | `application/json` |
+| 密钥 | 与 `OWLMAIL_WEBHOOK_SECRET` 完全相同 |
+| 超时 | 大于命令正常耗时；示例为 `10s` |
+| 重试 | 使用较小的有界值；示例为 `2` |
+
+示例请求体模板只发送联动所需字段，不会直接转发完整的内部邮件对象：
+
+```json
+{
+  "event": "email.received",
+  "emailId": "...",
+  "title": "...",
+  "message": "...",
+  "from": "...",
+  "to": "...",
+  "receivedAt": "..."
+}
+```
+
+挂载下载的配置文件，并通过参数或环境变量启用：
+
+```bash
+export OWLMAIL_WEBHOOK_URL=http://127.0.0.1:9000/hooks/owlmail
+export OWLMAIL_WEBHOOK_SECRET='替换为两边一致的随机密钥'
+owlmail -webhook-config ./owlmail.json
+```
+
+或者：
+
+```bash
+export OWLMAIL_WEBHOOK_CONFIG=/app/config/owlmail.json
+```
+
+OwlMail 会先展开环境变量，再验证配置；缺少变量或数值无效时会启动失败，不会
+静默关闭消息投递。
+
+## HMAC 约定
+
+OwlMail 对每次 HTTP 请求的原始请求体计算 HMAC-SHA256，并发送十六进制摘要：
+
+```text
+X-OwlMail-Signature: sha256=<十六进制摘要>
+```
+
+WebHook 的 `payload-hmac-sha256` 规则使用同一密钥校验完全相同的原始字节。链路
+中的代理不能改写或重新压缩请求体。签名不匹配时，WebHook 返回非 2xx 且不执行
+命令。
+
+## 生产环境检查清单
+
+- 将 WebHook 放在私有网络，或置于带身份认证的反向代理之后。
+- 即使使用容器私有网络也保留 HMAC；不要把共享密钥提交到仓库。
+- 尽量让 `-allowed-command-paths` 只包含明确的脚本路径。
+- 启用 `-strict-mode`、有界并发、执行超时与速率限制。
+- 邮件请求不要启用 `-debug` 和 `-log-request-body`。
+- 使用非特权用户运行命令，并以只读方式挂载脚本和配置。
+- 处理脚本必须幂等：OwlMail 会重试失败投递，同一邮件事件可能被处理多次。
+- OwlMail 超时应高于命令正常耗时，但不能无限延长 SMTP/事件链路等待时间。
+
+## 过滤与多工作流
+
+OwlMail 可以按发件人、收件人、主题和正文模式过滤目标。只需要处理部分邮件时，
+优先在发送端过滤。多个 OwlMail 目标可以调用不同 Hook ID，例如：
+
+- `/hooks/owlmail-archive`：处理全部邮件；
+- `/hooks/owlmail-alert`：仅处理主题匹配 `Critical*` 的邮件；
+- `/hooks/owlmail-ticket`：仅处理发送到 `support@example.com` 的邮件。
+
+每个端点应使用独立命令；条件允许时也使用独立密钥，以隔离权限和失败处理。
+
+## 故障排查
+
+| 现象 | 检查内容 |
+|---|---|
+| OwlMail 启动失败 | 配置路径、展开后的 URL/密钥、时长、模板和 JSON 语法。 |
+| WebHook 返回 401/403 | 两边密钥是否一致，代理是否修改请求体或签名头。 |
+| WebHook 返回 404 | 目标 URL 是否以 `/hooks/owlmail` 结尾，Hook ID 是否为 `owlmail`。 |
+| OwlMail 遇到 5xx 后重试 | 检查命令退出状态、WebHook 超时及并发日志。 |
+| 日志里没有命令输出 | 捕获的 stdout 不一定自动进入容器日志；根据工作流显式记录日志或执行副作用。 |
+| 同一事件重复处理 | 使用 `OWLMAIL_EMAIL_ID` 作为去重键，让命令保持幂等。 |
+
+[English](../en-US/OwlMail-Integration.md)

--- a/example/README.md
+++ b/example/README.md
@@ -7,5 +7,6 @@ This directory contains example configurations and setups for webhook.
 | **configs/** | General hook configuration examples: `hooks.yaml`, `hooks.json`, and Go template variants (`.tmpl`) for dynamic config. Use these as a starting point for your own `hooks.yaml` or `hooks.json`. |
 | **lark/** | [Lark (Feishu)](https://www.lark.com/) integration: `hook-lark.yaml` plus a sample script `send-lark-message.sh` and `docker-compose.yml` to run webhook and send messages to Lark. |
 | **multi-webhook/** | Multiple hooks and/or multiple webhook instances: separate hook files under `hooks/`, a `trigger.sh` script to call them, and `docker-compose.yml` to run a multi-instance setup. |
+| **owlmail/** | End-to-end [OwlMail](https://github.com/soulteary/owlmail) integration with HMAC verification, field mapping, bounded execution, and Docker Compose. |
 
 For full documentation, see the [English docs](../docs/en-US/) or [中文文档](../docs/zh-CN/).

--- a/example/owlmail/README.md
+++ b/example/owlmail/README.md
@@ -1,21 +1,22 @@
 # OwlMail integration example
 
-This example connects [OwlMail](https://github.com/soulteary/owlmail) to
+This example connects [OwlMail](https://github.com/soulteary/owlmail) `v0.5.0` to
 `soulteary/webhook`. Every accepted email is rendered as JSON, signed with
 HMAC-SHA256, verified by WebHook, and passed to a demo command through a fixed
 set of environment variables.
 
-The published OwlMail `v0.4.0` image predates webhook forwarding. The Compose
-example therefore builds OwlMail from its current `main` branch. Replace that
-build with a released OwlMail image after webhook forwarding is included in a
-release.
+OwlMail `v0.5.0` includes webhook forwarding, the `/webhooks` browser
+configurator, and bounded webhook delivery concurrency. The Compose demo uses
+the released `soulteary/owlmail:0.5.0` image directly and keeps the default
+OwlMail delivery concurrency of `8` explicit so the example documents the
+runtime behavior.
 
 ## Run
 
 ```bash
 cd example/owlmail
 export OWLMAIL_WEBHOOK_SECRET="$(openssl rand -hex 32)"
-docker compose up --build
+docker compose up
 ```
 
 Send a test message from another terminal:
@@ -29,7 +30,9 @@ printf 'From: monitor@example.test\r\nTo: ops@example.test\r\nSubject: Demo aler
 ```
 
 The `webhook` container logs a summary from `print-email.sh`. Open
-`http://127.0.0.1:1080` to inspect the captured message.
+`http://127.0.0.1:1080` to inspect the captured message. Open
+`http://127.0.0.1:1080/webhooks` to inspect OwlMail's webhook configurator and
+compare its generated configuration with `owlmail.json` in this directory.
 
 ```bash
 docker compose down

--- a/example/owlmail/README.md
+++ b/example/owlmail/README.md
@@ -35,8 +35,10 @@ The `webhook` container logs a summary from `print-email.sh`. Open
 docker compose down
 ```
 
-The example stores no persistent mail volume. It also keeps WebHook debug body
-logging disabled so message contents are not duplicated into request logs.
+The example stores no persistent mail volume. It enables WebHook debug logging
+so the demo command output is visible, but keeps raw request-body logging
+disabled. Disable `DEBUG` in production because the mapped email fields printed
+by the command will otherwise be written to logs.
 
 For configuration details, production guidance, field mappings, and
 troubleshooting, read the [OwlMail integration guide](../../docs/en-US/OwlMail-Integration.md).

--- a/example/owlmail/README.md
+++ b/example/owlmail/README.md
@@ -1,0 +1,44 @@
+# OwlMail integration example
+
+This example connects [OwlMail](https://github.com/soulteary/owlmail) to
+`soulteary/webhook`. Every accepted email is rendered as JSON, signed with
+HMAC-SHA256, verified by WebHook, and passed to a demo command through a fixed
+set of environment variables.
+
+The published OwlMail `v0.4.0` image predates webhook forwarding. The Compose
+example therefore builds OwlMail from its current `main` branch. Replace that
+build with a released OwlMail image after webhook forwarding is included in a
+release.
+
+## Run
+
+```bash
+cd example/owlmail
+export OWLMAIL_WEBHOOK_SECRET="$(openssl rand -hex 32)"
+docker compose up --build
+```
+
+Send a test message from another terminal:
+
+```bash
+printf 'From: monitor@example.test\r\nTo: ops@example.test\r\nSubject: Demo alert\r\n\r\nThe integration works.\r\n' \
+  | curl --url smtp://127.0.0.1:1025 \
+      --mail-from monitor@example.test \
+      --mail-rcpt ops@example.test \
+      --upload-file -
+```
+
+The `webhook` container logs a summary from `print-email.sh`. Open
+`http://127.0.0.1:1080` to inspect the captured message.
+
+```bash
+docker compose down
+```
+
+The example stores no persistent mail volume. It also keeps WebHook debug body
+logging disabled so message contents are not duplicated into request logs.
+
+For configuration details, production guidance, field mappings, and
+troubleshooting, read the [OwlMail integration guide](../../docs/en-US/OwlMail-Integration.md).
+
+[中文说明](./README.zh-CN.md)

--- a/example/owlmail/README.zh-CN.md
+++ b/example/owlmail/README.zh-CN.md
@@ -1,0 +1,43 @@
+# OwlMail 联动示例
+
+该示例将 [OwlMail](https://github.com/soulteary/owlmail) 与
+`soulteary/webhook` 连接起来。每封接收的邮件都会被渲染为 JSON，由 OwlMail
+使用 HMAC-SHA256 签名；WebHook 验证签名后，再通过一组固定环境变量将字段传给
+演示命令。
+
+当前已发布的 OwlMail `v0.4.0` 镜像早于 Webhook 转发功能，因此 Compose 示例
+会从 OwlMail 当前 `main` 分支构建。后续正式版本包含该功能后，可将 `build`
+替换为对应的 OwlMail 发布镜像。
+
+## 运行
+
+```bash
+cd example/owlmail
+export OWLMAIL_WEBHOOK_SECRET="$(openssl rand -hex 32)"
+docker compose up --build
+```
+
+在另一个终端发送测试邮件：
+
+```bash
+printf 'From: monitor@example.test\r\nTo: ops@example.test\r\nSubject: Demo alert\r\n\r\nThe integration works.\r\n' \
+  | curl --url smtp://127.0.0.1:1025 \
+      --mail-from monitor@example.test \
+      --mail-rcpt ops@example.test \
+      --upload-file -
+```
+
+`webhook` 容器会输出 `print-email.sh` 生成的摘要。打开
+`http://127.0.0.1:1080` 可以查看捕获的邮件。
+
+```bash
+docker compose down
+```
+
+示例未设置持久化邮件数据卷，也没有开启 WebHook 请求体调试日志，避免把邮件
+内容重复写入请求日志。
+
+配置说明、生产建议、字段映射和故障排查见
+[OwlMail 联动指南](../../docs/zh-CN/OwlMail-Integration.md)。
+
+[English](./README.md)

--- a/example/owlmail/README.zh-CN.md
+++ b/example/owlmail/README.zh-CN.md
@@ -34,8 +34,9 @@ printf 'From: monitor@example.test\r\nTo: ops@example.test\r\nSubject: Demo aler
 docker compose down
 ```
 
-示例未设置持久化邮件数据卷，也没有开启 WebHook 请求体调试日志，避免把邮件
-内容重复写入请求日志。
+示例未设置持久化邮件数据卷。为了让演示命令输出可见，它开启了 WebHook 调试
+日志，但仍关闭原始请求体日志。生产环境必须关闭 `DEBUG`，否则命令输出的邮件
+字段仍会进入日志。
 
 配置说明、生产建议、字段映射和故障排查见
 [OwlMail 联动指南](../../docs/zh-CN/OwlMail-Integration.md)。

--- a/example/owlmail/README.zh-CN.md
+++ b/example/owlmail/README.zh-CN.md
@@ -1,20 +1,21 @@
 # OwlMail 联动示例
 
-该示例将 [OwlMail](https://github.com/soulteary/owlmail) 与
+该示例将 [OwlMail](https://github.com/soulteary/owlmail) `v0.5.0` 与
 `soulteary/webhook` 连接起来。每封接收的邮件都会被渲染为 JSON，由 OwlMail
 使用 HMAC-SHA256 签名；WebHook 验证签名后，再通过一组固定环境变量将字段传给
 演示命令。
 
-当前已发布的 OwlMail `v0.4.0` 镜像早于 Webhook 转发功能，因此 Compose 示例
-会从 OwlMail 当前 `main` 分支构建。后续正式版本包含该功能后，可将 `build`
-替换为对应的 OwlMail 发布镜像。
+OwlMail `v0.5.0` 已正式包含 Webhook 转发、`/webhooks` 浏览器配置生成器，以及
+Webhook 投递并发上限。Compose Demo 直接使用发布镜像
+`soulteary/owlmail:0.5.0`，并显式设置默认并发值 `8`，让示例同时能够说明生产
+运行时行为。
 
 ## 运行
 
 ```bash
 cd example/owlmail
 export OWLMAIL_WEBHOOK_SECRET="$(openssl rand -hex 32)"
-docker compose up --build
+docker compose up
 ```
 
 在另一个终端发送测试邮件：
@@ -28,7 +29,9 @@ printf 'From: monitor@example.test\r\nTo: ops@example.test\r\nSubject: Demo aler
 ```
 
 `webhook` 容器会输出 `print-email.sh` 生成的摘要。打开
-`http://127.0.0.1:1080` 可以查看捕获的邮件。
+`http://127.0.0.1:1080` 可以查看捕获的邮件；打开
+`http://127.0.0.1:1080/webhooks` 可以查看 OwlMail 的 Webhook 配置生成器，并与
+本目录的 `owlmail.json` 示例进行对照。
 
 ```bash
 docker compose down

--- a/example/owlmail/compose.yaml
+++ b/example/owlmail/compose.yaml
@@ -1,0 +1,46 @@
+services:
+  webhook:
+    image: soulteary/webhook:extend-7.0.0
+    ports:
+      - "9000:9000"
+    environment:
+      HOST: "0.0.0.0"
+      PORT: "9000"
+      HOOKS: "/app/hooks.json.tmpl"
+      TEMPLATE: "true"
+      ALLOWED_COMMAND_PATHS: "/app/print-email.sh"
+      STRICT_MODE: "true"
+      MAX_CONCURRENT_HOOKS: "10"
+      HOOK_TIMEOUT_SECONDS: "15"
+      RATE_LIMIT_ENABLED: "true"
+      RATE_LIMIT_RPS: "20"
+      RATE_LIMIT_BURST: "10"
+      OWLMAIL_WEBHOOK_SECRET: "${OWLMAIL_WEBHOOK_SECRET:?set OWLMAIL_WEBHOOK_SECRET}"
+      OWLMAIL_WEBHOOK_COMMAND: "/app/print-email.sh"
+      OWLMAIL_WEBHOOK_WORKDIR: "/app"
+    volumes:
+      - ./hooks.json.tmpl:/app/hooks.json.tmpl:ro
+      - ./print-email.sh:/app/print-email.sh:ro
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:9000/health"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
+
+  owlmail:
+    build:
+      context: https://github.com/soulteary/owlmail.git#main
+    depends_on:
+      webhook:
+        condition: service_healthy
+    ports:
+      - "1025:1025"
+      - "1080:1080"
+    environment:
+      OWLMAIL_SMTP_HOST: "0.0.0.0"
+      OWLMAIL_WEB_HOST: "0.0.0.0"
+      OWLMAIL_WEBHOOK_CONFIG: "/app/config/owlmail.json"
+      OWLMAIL_WEBHOOK_URL: "http://webhook:9000/hooks/owlmail"
+      OWLMAIL_WEBHOOK_SECRET: "${OWLMAIL_WEBHOOK_SECRET:?set OWLMAIL_WEBHOOK_SECRET}"
+    volumes:
+      - ./owlmail.json:/app/config/owlmail.json:ro

--- a/example/owlmail/compose.yaml
+++ b/example/owlmail/compose.yaml
@@ -30,8 +30,7 @@ services:
       retries: 15
 
   owlmail:
-    build:
-      context: https://github.com/soulteary/owlmail.git#main
+    image: soulteary/owlmail:0.5.0
     depends_on:
       webhook:
         condition: service_healthy
@@ -42,6 +41,7 @@ services:
       OWLMAIL_SMTP_HOST: "0.0.0.0"
       OWLMAIL_WEB_HOST: "0.0.0.0"
       OWLMAIL_WEBHOOK_CONFIG: "/app/config/owlmail.json"
+      OWLMAIL_WEBHOOK_MAX_CONCURRENCY: "8"
       OWLMAIL_WEBHOOK_URL: "http://webhook:9000/hooks/owlmail"
       OWLMAIL_WEBHOOK_SECRET: "${OWLMAIL_WEBHOOK_SECRET:?set OWLMAIL_WEBHOOK_SECRET}"
     volumes:

--- a/example/owlmail/compose.yaml
+++ b/example/owlmail/compose.yaml
@@ -8,6 +8,8 @@ services:
       PORT: "9000"
       HOOKS: "/app/hooks.json.tmpl"
       TEMPLATE: "true"
+      DEBUG: "true"
+      LOG_REQUEST_BODY: "false"
       ALLOWED_COMMAND_PATHS: "/app/print-email.sh"
       STRICT_MODE: "true"
       MAX_CONCURRENT_HOOKS: "10"

--- a/example/owlmail/compose.yaml
+++ b/example/owlmail/compose.yaml
@@ -13,7 +13,7 @@ services:
       ALLOWED_COMMAND_PATHS: "/app/print-email.sh"
       STRICT_MODE: "true"
       MAX_CONCURRENT_HOOKS: "10"
-      HOOK_TIMEOUT_SECONDS: "15"
+      HOOK_EXECUTION_TIMEOUT: "8"
       RATE_LIMIT_ENABLED: "true"
       RATE_LIMIT_RPS: "20"
       RATE_LIMIT_BURST: "10"

--- a/example/owlmail/example_test.go
+++ b/example/owlmail/example_test.go
@@ -79,6 +79,7 @@ func TestOwlMailConfigAndDocumentation(t *testing.T) {
 		"DEBUG: \"true\"",
 		"LOG_REQUEST_BODY: \"false\"",
 		"ALLOWED_COMMAND_PATHS",
+		"HOOK_EXECUTION_TIMEOUT: \"8\"",
 		"STRICT_MODE",
 	} {
 		if !strings.Contains(string(compose), required) {

--- a/example/owlmail/example_test.go
+++ b/example/owlmail/example_test.go
@@ -76,6 +76,8 @@ func TestOwlMailConfigAndDocumentation(t *testing.T) {
 	for _, required := range []string{
 		"soulteary/webhook:extend-7.0.0",
 		"OWLMAIL_WEBHOOK_SECRET:?set OWLMAIL_WEBHOOK_SECRET",
+		"DEBUG: \"true\"",
+		"LOG_REQUEST_BODY: \"false\"",
 		"ALLOWED_COMMAND_PATHS",
 		"STRICT_MODE",
 	} {

--- a/example/owlmail/example_test.go
+++ b/example/owlmail/example_test.go
@@ -1,0 +1,97 @@
+package owlmail_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"text/template"
+)
+
+func TestHookTemplateRendersValidJSON(t *testing.T) {
+	data, err := os.ReadFile("hooks.json.tmpl")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	values := map[string]string{
+		"OWLMAIL_WEBHOOK_SECRET":  "test-secret",
+		"OWLMAIL_WEBHOOK_COMMAND": "/app/print-email.sh",
+		"OWLMAIL_WEBHOOK_WORKDIR": "/app",
+	}
+	tmpl, err := template.New("hooks").Funcs(template.FuncMap{
+		"getenv": func(name string) string { return values[name] },
+	}).Parse(string(data))
+	if err != nil {
+		t.Fatalf("parse hook template: %v", err)
+	}
+
+	var rendered bytes.Buffer
+	if err := tmpl.Execute(&rendered, nil); err != nil {
+		t.Fatalf("render hook template: %v", err)
+	}
+
+	var hooks []map[string]any
+	if err := json.Unmarshal(rendered.Bytes(), &hooks); err != nil {
+		t.Fatalf("rendered hook config is invalid JSON: %v\n%s", err, rendered.String())
+	}
+	if len(hooks) != 1 || hooks[0]["id"] != "owlmail" {
+		t.Fatalf("unexpected hooks: %#v", hooks)
+	}
+
+	rule := hooks[0]["trigger-rule"].(map[string]any)["match"].(map[string]any)
+	if rule["type"] != "payload-hmac-sha256" || rule["secret"] != "test-secret" {
+		t.Fatalf("unexpected HMAC rule: %#v", rule)
+	}
+}
+
+func TestOwlMailConfigAndDocumentation(t *testing.T) {
+	data, err := os.ReadFile("owlmail.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var config struct {
+		Version int `json:"version"`
+		Targets []struct {
+			URL    string `json:"url"`
+			Secret string `json:"secret"`
+		} `json:"targets"`
+	}
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("invalid OwlMail config: %v", err)
+	}
+	if config.Version != 1 || len(config.Targets) != 1 {
+		t.Fatalf("unexpected OwlMail config: %#v", config)
+	}
+	if config.Targets[0].URL != "${OWLMAIL_WEBHOOK_URL}" || config.Targets[0].Secret != "${OWLMAIL_WEBHOOK_SECRET}" {
+		t.Fatalf("OwlMail runtime variables are not preserved: %#v", config.Targets[0])
+	}
+
+	compose, err := os.ReadFile("compose.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, required := range []string{
+		"soulteary/webhook:extend-7.0.0",
+		"OWLMAIL_WEBHOOK_SECRET:?set OWLMAIL_WEBHOOK_SECRET",
+		"ALLOWED_COMMAND_PATHS",
+		"STRICT_MODE",
+	} {
+		if !strings.Contains(string(compose), required) {
+			t.Errorf("compose.yaml does not contain %q", required)
+		}
+	}
+
+	for _, path := range []string{
+		"README.md",
+		"README.zh-CN.md",
+		filepath.Join("..", "..", "docs", "en-US", "OwlMail-Integration.md"),
+		filepath.Join("..", "..", "docs", "zh-CN", "OwlMail-Integration.md"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("linked documentation %q is unavailable: %v", path, err)
+		}
+	}
+}

--- a/example/owlmail/example_test.go
+++ b/example/owlmail/example_test.go
@@ -75,6 +75,8 @@ func TestOwlMailConfigAndDocumentation(t *testing.T) {
 	}
 	for _, required := range []string{
 		"soulteary/webhook:extend-7.0.0",
+		"soulteary/owlmail:0.5.0",
+		"OWLMAIL_WEBHOOK_MAX_CONCURRENCY: \"8\"",
 		"OWLMAIL_WEBHOOK_SECRET:?set OWLMAIL_WEBHOOK_SECRET",
 		"DEBUG: \"true\"",
 		"LOG_REQUEST_BODY: \"false\"",
@@ -85,6 +87,9 @@ func TestOwlMailConfigAndDocumentation(t *testing.T) {
 		if !strings.Contains(string(compose), required) {
 			t.Errorf("compose.yaml does not contain %q", required)
 		}
+	}
+	if strings.Contains(string(compose), "github.com/soulteary/owlmail.git#main") {
+		t.Error("compose.yaml must use the released OwlMail image instead of an unpinned main build")
 	}
 
 	for _, path := range []string{

--- a/example/owlmail/hooks.json.tmpl
+++ b/example/owlmail/hooks.json.tmpl
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "owlmail",
+    "execute-command": "{{ getenv "OWLMAIL_WEBHOOK_COMMAND" | js }}",
+    "command-working-directory": "{{ getenv "OWLMAIL_WEBHOOK_WORKDIR" | js }}",
+    "http-methods": ["POST"],
+    "incoming-payload-content-type": "application/json",
+    "include-command-output-in-response": true,
+    "include-command-output-in-response-on-error": false,
+    "pass-environment-to-command": [
+      { "source": "payload", "name": "event", "envname": "OWLMAIL_EVENT" },
+      { "source": "payload", "name": "emailId", "envname": "OWLMAIL_EMAIL_ID" },
+      { "source": "payload", "name": "title", "envname": "OWLMAIL_TITLE" },
+      { "source": "payload", "name": "message", "envname": "OWLMAIL_MESSAGE" },
+      { "source": "payload", "name": "from", "envname": "OWLMAIL_FROM" },
+      { "source": "payload", "name": "to", "envname": "OWLMAIL_TO" },
+      { "source": "payload", "name": "receivedAt", "envname": "OWLMAIL_RECEIVED_AT" }
+    ],
+    "trigger-rule": {
+      "match": {
+        "type": "payload-hmac-sha256",
+        "secret": "{{ getenv "OWLMAIL_WEBHOOK_SECRET" | js }}",
+        "parameter": {
+          "source": "header",
+          "name": "X-OwlMail-Signature"
+        }
+      }
+    }
+  }
+]

--- a/example/owlmail/owlmail.json
+++ b/example/owlmail/owlmail.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "targets": [
+    {
+      "name": "soulteary-webhook",
+      "url": "${OWLMAIL_WEBHOOK_URL}",
+      "secret": "${OWLMAIL_WEBHOOK_SECRET}",
+      "timeout": "10s",
+      "retries": 2,
+      "bodyTemplate": "{\"event\":\"email.received\",\"emailId\":{{ json .ID }},\"title\":{{ json .Subject }},\"message\":{{ json (truncate .Text 4000) }},\"from\":{{ json (join .From \",\") }},\"to\":{{ json (join .To \",\") }},\"receivedAt\":{{ json .Time }}}"
+    }
+  ]
+}

--- a/example/owlmail/print-email.sh
+++ b/example/owlmail/print-email.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+printf '%s\n' \
+  "OwlMail webhook event" \
+  "  event: ${OWLMAIL_EVENT:-}" \
+  "  id: ${OWLMAIL_EMAIL_ID:-}" \
+  "  title: ${OWLMAIL_TITLE:-}" \
+  "  from: ${OWLMAIL_FROM:-}" \
+  "  to: ${OWLMAIL_TO:-}" \
+  "  received: ${OWLMAIL_RECEIVED_AT:-}" \
+  "  message: ${OWLMAIL_MESSAGE:-}"


### PR DESCRIPTION
## Summary

- add English and Chinese guides for connecting OwlMail v0.5.0 email events to WebHook
- add a runnable Docker Compose demo using the released `soulteary/owlmail:0.5.0` image
- demonstrate HMAC-SHA256 verification, payload-to-environment mapping, command allowlisting, strict mode, bounded WebHook execution, rate limiting, and OwlMail's process-wide webhook concurrency limit
- document OwlMail's `/webhooks` configurator, config mounting, retries/idempotency, filtering, and production hardening
- link the integration from both root READMEs and the example index
- add regression tests that render the hook template and pin the demo to OwlMail v0.5.0 instead of an unpinned `main` build

## OwlMail v0.5.0 alignment

OwlMail v0.5.0 is now released with webhook forwarding and the browser configurator. The demo therefore no longer builds OwlMail from `main`; it consumes the released `0.5.0` image directly. It also makes `OWLMAIL_WEBHOOK_MAX_CONCURRENCY=8` explicit, matching OwlMail's safe default while documenting that `0` means intentionally unlimited delivery.

## Demo

```bash
cd example/owlmail
export OWLMAIL_WEBHOOK_SECRET="$(openssl rand -hex 32)"
docker compose up
```

Send a test email to `smtp://127.0.0.1:1025`, inspect the inbox at `http://127.0.0.1:1080`, and inspect/generate webhook configuration at `http://127.0.0.1:1080/webhooks`. The WebHook container receives the signed event, verifies it, maps selected mail fields, and runs the bounded demo handler.

## Validation

- parsed `example/owlmail/owlmail.json`
- rendered `hooks.json.tmpl` with representative environment values and parsed the resulting JSON
- regression test checks `soulteary/owlmail:0.5.0`, concurrency `8`, and rejects the previous unpinned `main` build
- verified bilingual documentation links and runtime-variable placeholders
- repository CI remains the source of truth for full `go test ./...` and Compose execution
