### PR TITLE
fix: bind OwlMail demo ports to loopback

### DIFF
--- a/example/owlmail/README.md
+++ b/example/owlmail/README.md
@@ -19,6 +19,9 @@ export OWLMAIL_WEBHOOK_SECRET="$(openssl rand -hex 32)"
 docker compose up
 ```
 
+All published demo ports bind to `127.0.0.1`, so the SMTP listener, inbox UI,
+and WebHook endpoint are not exposed to other hosts on the network.
+
 Send a test message from another terminal:
 
 ```bash

--- a/example/owlmail/README.zh-CN.md
+++ b/example/owlmail/README.zh-CN.md
@@ -18,6 +18,9 @@ export OWLMAIL_WEBHOOK_SECRET="$(openssl rand -hex 32)"
 docker compose up
 ```
 
+Demo 发布的所有端口均绑定到 `127.0.0.1`，因此 SMTP 监听器、收件箱界面和
+WebHook 端点不会暴露给网络中的其他主机。
+
 在另一个终端发送测试邮件：
 
 ```bash

--- a/example/owlmail/compose.yaml
+++ b/example/owlmail/compose.yaml
@@ -2,7 +2,7 @@ services:
   webhook:
     image: soulteary/webhook:extend-7.0.0
     ports:
-      - "9000:9000"
+      - "127.0.0.1:9000:9000"
     environment:
       HOST: "0.0.0.0"
       PORT: "9000"
@@ -35,8 +35,8 @@ services:
       webhook:
         condition: service_healthy
     ports:
-      - "1025:1025"
-      - "1080:1080"
+      - "127.0.0.1:1025:1025"
+      - "127.0.0.1:1080:1080"
     environment:
       OWLMAIL_SMTP_HOST: "0.0.0.0"
       OWLMAIL_WEB_HOST: "0.0.0.0"

--- a/example/owlmail/example_test.go
+++ b/example/owlmail/example_test.go
@@ -76,6 +76,9 @@ func TestOwlMailConfigAndDocumentation(t *testing.T) {
 	for _, required := range []string{
 		"soulteary/webhook:extend-7.0.0",
 		"soulteary/owlmail:0.5.0",
+		"127.0.0.1:9000:9000",
+		"127.0.0.1:1025:1025",
+		"127.0.0.1:1080:1080",
 		"OWLMAIL_WEBHOOK_MAX_CONCURRENCY: \"8\"",
 		"OWLMAIL_WEBHOOK_SECRET:?set OWLMAIL_WEBHOOK_SECRET",
 		"DEBUG: \"true\"",
@@ -90,6 +93,15 @@ func TestOwlMailConfigAndDocumentation(t *testing.T) {
 	}
 	if strings.Contains(string(compose), "github.com/soulteary/owlmail.git#main") {
 		t.Error("compose.yaml must use the released OwlMail image instead of an unpinned main build")
+	}
+	for _, unsafe := range []string{
+		`- "9000:9000"`,
+		`- "1025:1025"`,
+		`- "1080:1080"`,
+	} {
+		if strings.Contains(string(compose), unsafe) {
+			t.Errorf("compose.yaml publishes a demo port on every host interface: %s", unsafe)
+		}
 	}
 
 	for _, path := range []string{


### PR DESCRIPTION
## Summary

- bind the WebHook, SMTP, and OwlMail UI host ports to `127.0.0.1`
- keep container-to-container communication unchanged
- document that the runnable demo is local-only by default
- add regression assertions that reject wildcard host-port mappings

## Validation

- `go test ./example/owlmail`
- parsed `example/owlmail/compose.yaml` and verified all published ports use loopback
- `gofmt` on the changed test
- `git diff --check`