### PR TITLE
ci: align Go toolchain with go.mod

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ on:
       - "*.*.*"
 
 env:
-  GO_VERSION: "1.26.6"
   GO111MODULE: on
   DOCKER_CLI_EXPERIMENTAL: "enabled"
 
@@ -29,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,9 +23,6 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
-env:
-  GO_VERSION: "1.26.6"
-
 permissions:
   actions: read
   contents: read
@@ -48,7 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      GO_VERSION: "1.26.6"
       GO111MODULE: on
     steps:
       - name: Checkout
@@ -27,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Cache Go modules
         uses: actions/cache@v5

--- a/docker/manual/Dockerfile
+++ b/docker/manual/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.6-bullseye AS builder
+FROM golang:1.27.0-bullseye AS builder
 ENV GOPROXY=https://goproxy.cn
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/docker/manual/Dockerfile
+++ b/docker/manual/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.27.0-bullseye AS builder
+FROM golang:1.27.0-bookworm AS builder
 ENV GOPROXY=https://goproxy.cn
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/docker/manual/Dockerfile.alpine
+++ b/docker/manual/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM golang:1.26.6-alpine3.23 as builder
+FROM golang:1.27.0-alpine3.23 AS builder
 RUN apk --update add ca-certificates upx
 ENV GOPROXY=https://goproxy.cn
 ENV CGO_ENABLED=0


### PR DESCRIPTION
## Summary

- make the CodeQL, release, and test workflows read the required Go version from `go.mod`
- update both manual Docker build images from Go 1.26.6 to published Go 1.27.0 variants
- keep the standard manual image's Bullseye runtime while using a Bookworm builder; the binary is built with `CGO_ENABLED=0`
- normalize the multi-stage Dockerfile stage keyword while touching the image reference

## Root cause

The dependency update in `25de8e31ea12e434abc81d3ba3a13517d90dbd14` raised the module requirement to Go 1.27.0, while CodeQL still installed Go 1.26.6. CodeQL sets `GOTOOLCHAIN=local`, so its autobuild could not switch toolchains and failed before analysis with:

```
go: go.mod requires go >= 1.27.0 (running go 1.26.6; GOTOOLCHAIN=local)
```

## Verification

- CodeQL: passed; the previously failing Autobuild step now succeeds
- Tests: passed
- Security Scan: passed
- Codex review feedback about the unavailable `golang:1.27.0-bullseye` tag was fixed with `golang:1.27.0-bookworm` and the thread was resolved

Fixes the failure in workflow run 33824747512, job 100874903061.