### PR TITLE
fix: retain stable Prometheus label values

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -318,3 +318,29 @@ func (RateLimitMetrics) RecordHookHit() {
 // RecordGlobalHit 记录全局限流命中
 func (RateLimitMetrics) RecordGlobalHit() {
 	RecordRateLimitHit("global")
+}
+
+// TriggerRuleMetrics 提供触发规则指标的便捷方法
+type TriggerRuleMetrics struct{}
+
+// RecordMatched 记录规则匹配
+func (TriggerRuleMetrics) RecordMatched(hookID string) {
+	RecordTriggerRuleEvaluation(hookID, "matched")
+}
+
+// RecordNotMatched 记录规则不匹配
+func (TriggerRuleMetrics) RecordNotMatched(hookID string) {
+	RecordTriggerRuleEvaluation(hookID, "not_matched")
+}
+
+// RecordError 记录规则评估错误
+func (TriggerRuleMetrics) RecordError(hookID string) {
+	RecordTriggerRuleEvaluation(hookID, "error")
+}
+
+// 全局便捷实例
+var (
+	Signature   SignatureMetrics
+	RateLimit   RateLimitMetrics
+	TriggerRule TriggerRuleMetrics
+)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -149,12 +150,15 @@ func initMetrics() {
 
 // RecordHookExecution 记录 hook 执行
 func RecordHookExecution(hookID, status string, duration time.Duration) {
+	hookID = strings.Clone(hookID)
+	status = strings.Clone(status)
 	HookExecutions.WithLabelValues(hookID, status).Inc()
 	HookDuration.WithLabelValues(hookID).Observe(duration.Seconds())
 }
 
 // IncrementConcurrentHooks 增加并发 hook 计数
 func IncrementConcurrentHooks(hookID string) {
+	hookID = strings.Clone(hookID)
 	concurrentHooksMu.Lock()
 	defer concurrentHooksMu.Unlock()
 	concurrentHooksMap[hookID]++
@@ -163,6 +167,7 @@ func IncrementConcurrentHooks(hookID string) {
 
 // DecrementConcurrentHooks 减少并发 hook 计数
 func DecrementConcurrentHooks(hookID string) {
+	hookID = strings.Clone(hookID)
 	concurrentHooksMu.Lock()
 	defer concurrentHooksMu.Unlock()
 	if count, exists := concurrentHooksMap[hookID]; exists && count > 0 {
@@ -176,6 +181,12 @@ func DecrementConcurrentHooks(hookID string) {
 
 // RecordHTTPRequest 记录 HTTP 请求
 func RecordHTTPRequest(method, statusCode, path string, duration time.Duration) {
+	// Fiber's net/http adaptor exposes request strings backed by fasthttp's
+	// reusable request buffer. Prometheus keeps label strings after the request
+	// returns, so each value must own its storage before it is retained.
+	method = strings.Clone(method)
+	statusCode = strings.Clone(statusCode)
+	path = strings.Clone(path)
 	HTTPRequests.WithLabelValues(method, statusCode, path).Inc()
 	HTTPRequestDuration.WithLabelValues(method, path).Observe(duration.Seconds())
 }
@@ -185,6 +196,8 @@ func RecordHTTPRequest(method, statusCode, path string, duration time.Duration) 
 // algorithm: "sha256", "sha512", "sha1", "md5" 等
 func RecordSignatureVerify(result, algorithm string) {
 	if SignatureVerify != nil {
+		result = strings.Clone(result)
+		algorithm = strings.Clone(algorithm)
 		SignatureVerify.WithLabelValues(result, algorithm).Inc()
 	}
 }
@@ -193,6 +206,7 @@ func RecordSignatureVerify(result, algorithm string) {
 // scope: "ip", "user", "hook", "global" 等
 func RecordRateLimitHit(scope string) {
 	if RateLimitHits != nil {
+		scope = strings.Clone(scope)
 		RateLimitHits.WithLabelValues(scope).Inc()
 	}
 }
@@ -201,6 +215,8 @@ func RecordRateLimitHit(scope string) {
 // result: "matched", "not_matched", "error"
 func RecordTriggerRuleEvaluation(hookID, result string) {
 	if TriggerRules != nil {
+		hookID = strings.Clone(hookID)
+		result = strings.Clone(result)
 		TriggerRules.WithLabelValues(hookID, result).Inc()
 	}
 }
@@ -302,29 +318,3 @@ func (RateLimitMetrics) RecordHookHit() {
 // RecordGlobalHit 记录全局限流命中
 func (RateLimitMetrics) RecordGlobalHit() {
 	RecordRateLimitHit("global")
-}
-
-// TriggerRuleMetrics 提供触发规则指标的便捷方法
-type TriggerRuleMetrics struct{}
-
-// RecordMatched 记录规则匹配
-func (TriggerRuleMetrics) RecordMatched(hookID string) {
-	RecordTriggerRuleEvaluation(hookID, "matched")
-}
-
-// RecordNotMatched 记录规则不匹配
-func (TriggerRuleMetrics) RecordNotMatched(hookID string) {
-	RecordTriggerRuleEvaluation(hookID, "not_matched")
-}
-
-// RecordError 记录规则评估错误
-func (TriggerRuleMetrics) RecordError(hookID string) {
-	RecordTriggerRuleEvaluation(hookID, "error")
-}
-
-// 全局便捷实例
-var (
-	Signature   SignatureMetrics
-	RateLimit   RateLimitMetrics
-	TriggerRule TriggerRuleMetrics
-)

--- a/internal/server/metrics_lifetime_test.go
+++ b/internal/server/metrics_lifetime_test.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/soulteary/webhook/internal/flags"
+	"github.com/soulteary/webhook/internal/hook"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetricsRemainCollectableAfterAdaptedRequests(t *testing.T) {
+	appFlags := flags.AppFlags{
+		HooksURLPrefix:  "/hooks",
+		ResponseHeaders: hook.ResponseHeaders{},
+	}
+
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = ln.Close() }()
+
+	server := Launch(appFlags, ln.Addr().String(), ln)
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = server.Shutdown(ctx)
+	}()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	baseURL := "http://" + ln.Addr().String()
+	require.Eventually(t, func() bool {
+		resp, requestErr := client.Get(baseURL + "/")
+		if requestErr != nil {
+			return false
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, time.Second, 10*time.Millisecond)
+
+	for _, path := range []string{"/health", "/livez", "/readyz", "/version"} {
+		for _, method := range []string{http.MethodGet, http.MethodHead, http.MethodPost, http.MethodOptions} {
+			req, requestErr := http.NewRequest(method, baseURL+path, nil)
+			require.NoError(t, requestErr)
+			resp, requestErr := client.Do(req)
+			require.NoError(t, requestErr)
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}
+	}
+
+	resp, err := client.Get(baseURL + "/metrics")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+	assert.NotContains(t, strings.ToLower(string(body)), "error has occurred")
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -680,6 +680,10 @@ func createHookHandler(appFlags flags.AppFlags, srv *Server) func(w http.Respons
 			audit.LogHookNotFound(requestID, hookID, r.RemoteAddr, r.UserAgent())
 			return
 		}
+		// URL strings produced by the Fiber/fasthttp adaptor are backed by a
+		// reusable request buffer. Use the configured hook ID before any value is
+		// captured by asynchronous execution or retained by metrics and audit logs.
+		hookID = matchedHook.ID
 
 		// Check for allowed methods
 		if !isMethodAllowed(r.Method, matchedHook, appFlags) {


### PR DESCRIPTION
## Summary

- clone metric label strings before Prometheus retains them
- cover HTTP, hook, concurrency, signature, rate-limit, and trigger-rule labels
- add an integration regression test that sends mixed methods through Fiber's net/http adaptor and then scrapes `/metrics`

## Why

Fiber's fasthttp adaptor exposes request strings backed by reusable request buffers. Prometheus retains label strings after the adapted handler returns. Under normal mixed traffic, labels such as `GET` and `POST` were mutated into values such as `GETD` and `POS`, causing duplicate metric families and making `/metrics` return `500 Internal Server Error`.

## Validation

- `go test ./internal/metrics ./internal/server -count=1`
- `go test -race ./internal/metrics ./internal/server -run 'TestMetricsRemainCollectableAfterAdaptedRequests|TestRecordHTTPRequest|TestConcurrent' -count=1`
- `git diff --check`
