### PR TITLE
fix: enforce read-only HTTP method contracts

### DIFF
--- a/internal/configui/configui.go
+++ b/internal/configui/configui.go
@@ -488,14 +488,14 @@ func Handler(basePath string, webhookBaseURL string, writeDir string, hooksURLPr
 
 	// Index: exact basePath or basePath/
 	indexHandler := func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet && r.Method != http.MethodHead {
-			w.Header().Set("Allow", "GET, HEAD")
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
 		path := r.URL.Path
 		if path != basePath && path != basePath+"/" {
 			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			w.Header().Set("Allow", "GET, HEAD")
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/internal/configui/configui.go
+++ b/internal/configui/configui.go
@@ -441,16 +441,6 @@ func Handler(basePath string, webhookBaseURL string, writeDir string, hooksURLPr
 	}
 	subFS, _ := fs.Sub(staticFS, "static")
 	staticHandler := http.FileServer(http.FS(subFS))
-	readOnly := func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method != http.MethodGet && r.Method != http.MethodHead {
-				w.Header().Set("Allow", "GET, HEAD")
-				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-				return
-			}
-			next.ServeHTTP(w, r)
-		})
-	}
 
 	// When basePath is "/", subpaths must be "/static/" and "/api/generate" (no "//").
 	pathPrefix := basePath
@@ -463,7 +453,22 @@ func Handler(basePath string, webhookBaseURL string, writeDir string, hooksURLPr
 	// Register more specific routes before "/" so they match when basePath is "/".
 	// Static files: basePath/static/ or /static/ when basePath is "/"
 	// Strip pathPrefix+"/static/" so path becomes "css/..." or "js/..." for subFS (root is static dir).
-	mux.Handle(pathPrefix+"/static/", readOnly(http.StripPrefix(pathPrefix+"/static/", staticHandler)))
+	staticPrefix := pathPrefix + "/static/"
+	strippedStaticHandler := http.StripPrefix(staticPrefix, staticHandler)
+	mux.Handle(staticPrefix, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			assetPath := strings.TrimPrefix(r.URL.Path, staticPrefix)
+			if _, err := fs.Stat(subFS, assetPath); err != nil {
+				// Preserve the file server's 404 response for resources that do not exist.
+				strippedStaticHandler.ServeHTTP(w, r)
+				return
+			}
+			w.Header().Set("Allow", "GET, HEAD")
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		strippedStaticHandler.ServeHTTP(w, r)
+	}))
 
 	// API: basePath/api/generate or /api/generate when basePath is "/"
 	mux.HandleFunc(pathPrefix+"/api/generate", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/configui/configui.go
+++ b/internal/configui/configui.go
@@ -217,6 +217,7 @@ func requestToHook(req *generateRequest) *hook.Hook {
 
 func runGenerate(w http.ResponseWriter, r *http.Request, webhookBaseURL string, hooksURLPrefix string) {
 	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
@@ -280,6 +281,7 @@ type saveRequest struct {
 
 func runSave(w http.ResponseWriter, r *http.Request, writeDir string) {
 	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
@@ -439,6 +441,16 @@ func Handler(basePath string, webhookBaseURL string, writeDir string, hooksURLPr
 	}
 	subFS, _ := fs.Sub(staticFS, "static")
 	staticHandler := http.FileServer(http.FS(subFS))
+	readOnly := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet && r.Method != http.MethodHead {
+				w.Header().Set("Allow", "GET, HEAD")
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
 
 	// When basePath is "/", subpaths must be "/static/" and "/api/generate" (no "//").
 	pathPrefix := basePath
@@ -451,7 +463,7 @@ func Handler(basePath string, webhookBaseURL string, writeDir string, hooksURLPr
 	// Register more specific routes before "/" so they match when basePath is "/".
 	// Static files: basePath/static/ or /static/ when basePath is "/"
 	// Strip pathPrefix+"/static/" so path becomes "css/..." or "js/..." for subFS (root is static dir).
-	mux.Handle(pathPrefix+"/static/", http.StripPrefix(pathPrefix+"/static/", staticHandler))
+	mux.Handle(pathPrefix+"/static/", readOnly(http.StripPrefix(pathPrefix+"/static/", staticHandler)))
 
 	// API: basePath/api/generate or /api/generate when basePath is "/"
 	mux.HandleFunc(pathPrefix+"/api/generate", func(w http.ResponseWriter, r *http.Request) {
@@ -466,6 +478,7 @@ func Handler(basePath string, webhookBaseURL string, writeDir string, hooksURLPr
 	// API: basePath/api/capabilities — whether save-to-dir is available
 	mux.HandleFunc(pathPrefix+"/api/capabilities", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
@@ -475,6 +488,11 @@ func Handler(basePath string, webhookBaseURL string, writeDir string, hooksURLPr
 
 	// Index: exact basePath or basePath/
 	indexHandler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			w.Header().Set("Allow", "GET, HEAD")
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
 		path := r.URL.Path
 		if path != basePath && path != basePath+"/" {
 			http.NotFound(w, r)

--- a/internal/configui/configui.go
+++ b/internal/configui/configui.go
@@ -458,10 +458,12 @@ func Handler(basePath string, webhookBaseURL string, writeDir string, hooksURLPr
 	mux.Handle(staticPrefix, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet && r.Method != http.MethodHead {
 			assetPath := strings.TrimPrefix(r.URL.Path, staticPrefix)
-			if _, err := fs.Stat(subFS, assetPath); err != nil {
-				// Preserve the file server's 404 response for resources that do not exist.
-				strippedStaticHandler.ServeHTTP(w, r)
-				return
+			if assetPath != "" {
+				if _, err := fs.Stat(subFS, assetPath); err != nil {
+					// Preserve the file server's 404 response for resources that do not exist.
+					strippedStaticHandler.ServeHTTP(w, r)
+					return
+				}
 			}
 			w.Header().Set("Allow", "GET, HEAD")
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)

--- a/internal/configui/configui_test.go
+++ b/internal/configui/configui_test.go
@@ -387,6 +387,16 @@ func TestHandlerReadOnlyResourcesRejectOtherMethods(t *testing.T) {
 			}
 		})
 	}
+
+	req := httptest.NewRequest(http.MethodPost, "http://test/config-ui/unknown", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("POST /config-ui/unknown: status %d, want 404", rec.Code)
+	}
+	if got := rec.Header().Get("Allow"); got != "" {
+		t.Fatalf("POST /config-ui/unknown: unexpected Allow header %q", got)
+	}
 }
 
 func TestHandlerAPISaveNoWriteDir(t *testing.T) {

--- a/internal/configui/configui_test.go
+++ b/internal/configui/configui_test.go
@@ -330,6 +330,9 @@ func TestHandlerAPIGenerateMethodNotAllowed(t *testing.T) {
 	if w.Code != http.StatusMethodNotAllowed {
 		t.Errorf("GET /api/generate: status %d, want 405", w.Code)
 	}
+	if got := w.Header().Get("Allow"); got != http.MethodPost {
+		t.Errorf("GET /api/generate: Allow %q, want POST", got)
+	}
 }
 
 func TestHandlerAPICapabilitiesMethodNotAllowed(t *testing.T) {
@@ -342,6 +345,9 @@ func TestHandlerAPICapabilitiesMethodNotAllowed(t *testing.T) {
 	h.ServeHTTP(w, req)
 	if w.Code != http.StatusMethodNotAllowed {
 		t.Errorf("POST /api/capabilities: status %d, want 405", w.Code)
+	}
+	if got := w.Header().Get("Allow"); got != http.MethodGet {
+		t.Errorf("POST /api/capabilities: Allow %q, want GET", got)
 	}
 }
 
@@ -356,6 +362,30 @@ func TestHandlerAPISaveMethodNotAllowed(t *testing.T) {
 	h.ServeHTTP(w, req)
 	if w.Code != http.StatusMethodNotAllowed {
 		t.Errorf("GET /api/save: status %d, want 405", w.Code)
+	}
+	if got := w.Header().Get("Allow"); got != http.MethodPost {
+		t.Errorf("GET /api/save: Allow %q, want POST", got)
+	}
+}
+
+func TestHandlerReadOnlyResourcesRejectOtherMethods(t *testing.T) {
+	h, err := Handler("/config-ui", "http://localhost:9000", "", "/hooks")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range []string{"/config-ui", "/config-ui/", "/config-ui/static/js/app.js"} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "http://test"+path, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != http.StatusMethodNotAllowed {
+				t.Fatalf("POST %s: status %d, want 405", path, rec.Code)
+			}
+			if got := rec.Header().Get("Allow"); got != "GET, HEAD" {
+				t.Fatalf("POST %s: Allow %q, want GET, HEAD", path, got)
+			}
+		})
 	}
 }
 

--- a/internal/configui/configui_test.go
+++ b/internal/configui/configui_test.go
@@ -374,7 +374,7 @@ func TestHandlerReadOnlyResourcesRejectOtherMethods(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, path := range []string{"/config-ui", "/config-ui/", "/config-ui/static/js/app.js"} {
+	for _, path := range []string{"/config-ui", "/config-ui/", "/config-ui/static/", "/config-ui/static/js/app.js"} {
 		t.Run(path, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, "http://test"+path, nil)
 			rec := httptest.NewRecorder()

--- a/internal/configui/configui_test.go
+++ b/internal/configui/configui_test.go
@@ -397,6 +397,16 @@ func TestHandlerReadOnlyResourcesRejectOtherMethods(t *testing.T) {
 	if got := rec.Header().Get("Allow"); got != "" {
 		t.Fatalf("POST /config-ui/unknown: unexpected Allow header %q", got)
 	}
+
+	req = httptest.NewRequest(http.MethodPost, "http://test/config-ui/static/missing.js", nil)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("POST /config-ui/static/missing.js: status %d, want 404", rec.Code)
+	}
+	if got := rec.Header().Get("Allow"); got != "" {
+		t.Fatalf("POST /config-ui/static/missing.js: unexpected Allow header %q", got)
+	}
 }
 
 func TestHandlerAPISaveNoWriteDir(t *testing.T) {

--- a/internal/server/web.go
+++ b/internal/server/web.go
@@ -35,6 +35,20 @@ type Server struct {
 	shutdown bool
 }
 
+func registerReadOnlyRoute(app *fiber.App, path string, handler fiber.Handler) {
+	app.Get(path, handler)
+	app.Head(path, handler)
+	app.All(path, func(c fiber.Ctx) error {
+		startTime := time.Now()
+		method := strings.Clone(c.Method())
+		defer func() {
+			metrics.RecordHTTPRequest(method, "405", path, time.Since(startTime))
+		}()
+		c.Set("Allow", "GET, HEAD")
+		return c.Status(http.StatusMethodNotAllowed).SendString(http.StatusText(http.StatusMethodNotAllowed))
+	})
+}
+
 // Launch 启动 HTTP 服务器并返回 Server 实例（基于 fiber.App）
 func Launch(appFlags flags.AppFlags, addr string, ln net.Listener) *Server {
 	// Clean up input
@@ -160,7 +174,7 @@ func Launch(appFlags flags.AppFlags, addr string, ln net.Listener) *Server {
 		statusCode := healthkit.HTTPStatusCode(result.Status)
 		metrics.RecordHTTPRequest(r.Method, fmt.Sprintf("%d", statusCode), "/health", duration)
 	}
-	app.All("/health", adaptor.HTTPHandlerFunc(healthHandler))
+	registerReadOnlyRoute(app, "/health", adaptor.HTTPHandlerFunc(healthHandler))
 
 	livezHandler := func(w http.ResponseWriter, r *http.Request) {
 		startTime := time.Now()
@@ -168,7 +182,7 @@ func Launch(appFlags flags.AppFlags, addr string, ln net.Listener) *Server {
 		handler(w, r)
 		metrics.RecordHTTPRequest(r.Method, "200", "/livez", time.Since(startTime))
 	}
-	app.All("/livez", adaptor.HTTPHandlerFunc(livezHandler))
+	registerReadOnlyRoute(app, "/livez", adaptor.HTTPHandlerFunc(livezHandler))
 
 	readyzHandler := func(w http.ResponseWriter, r *http.Request) {
 		startTime := time.Now()
@@ -179,7 +193,7 @@ func Launch(appFlags flags.AppFlags, addr string, ln net.Listener) *Server {
 		statusCode := healthkit.HTTPStatusCode(result.Status)
 		metrics.RecordHTTPRequest(r.Method, fmt.Sprintf("%d", statusCode), "/readyz", duration)
 	}
-	app.All("/readyz", adaptor.HTTPHandlerFunc(readyzHandler))
+	registerReadOnlyRoute(app, "/readyz", adaptor.HTTPHandlerFunc(readyzHandler))
 
 	versionInfo := version.GetVersionInfo()
 	versionConfig := versionkit.HandlerConfig{
@@ -194,20 +208,9 @@ func Launch(appFlags flags.AppFlags, addr string, ln net.Listener) *Server {
 		handler(w, r)
 		metrics.RecordHTTPRequest(r.Method, "200", "/version", time.Since(startTime))
 	}
-	versionHTTPHandler := adaptor.HTTPHandlerFunc(versionHandler)
-	app.Get("/version", versionHTTPHandler)
-	app.Head("/version", versionHTTPHandler)
-	app.All("/version", func(c fiber.Ctx) error {
-		startTime := time.Now()
-		method := c.Method()
-		defer func() {
-			metrics.RecordHTTPRequest(method, "405", "/version", time.Since(startTime))
-		}()
-		c.Set("Allow", "GET, HEAD")
-		return c.Status(http.StatusMethodNotAllowed).SendString(http.StatusText(http.StatusMethodNotAllowed))
-	})
+	registerReadOnlyRoute(app, "/version", adaptor.HTTPHandlerFunc(versionHandler))
 
-	app.All("/metrics", adaptor.HTTPHandler(promhttp.Handler()))
+	registerReadOnlyRoute(app, "/metrics", adaptor.HTTPHandler(promhttp.Handler()))
 
 	rootHandler := func(w http.ResponseWriter, r *http.Request) {
 		startTime := time.Now()
@@ -217,7 +220,7 @@ func Launch(appFlags flags.AppFlags, addr string, ln net.Listener) *Server {
 		setResponseHeaders(w, appFlags.ResponseHeaders)
 		_, _ = fmt.Fprint(w, "OK")
 	}
-	app.All("/", adaptor.HTTPHandlerFunc(rootHandler))
+	registerReadOnlyRoute(app, "/", adaptor.HTTPHandlerFunc(rootHandler))
 
 	var openapiPathLogged string
 	if appFlags.OpenAPIEnabled {

--- a/internal/server/web_test.go
+++ b/internal/server/web_test.go
@@ -325,6 +325,49 @@ func TestLaunch_MetricsEndpoint(t *testing.T) {
 	}
 }
 
+func TestLaunch_ReadOnlyEndpointsRejectOtherMethods(t *testing.T) {
+	appFlags := flags.AppFlags{
+		HooksURLPrefix:  "/hooks",
+		ResponseHeaders: hook.ResponseHeaders{},
+	}
+
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = ln.Close() }()
+
+	server := Launch(appFlags, ln.Addr().String(), ln)
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = server.Shutdown(ctx)
+	}()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	baseURL := "http://" + ln.Addr().String()
+	require.Eventually(t, func() bool {
+		resp, requestErr := client.Get(baseURL + "/")
+		if requestErr != nil {
+			return false
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, time.Second, 10*time.Millisecond)
+
+	for _, path := range []string{"/", "/health", "/livez", "/readyz", "/version", "/metrics"} {
+		for _, method := range []string{http.MethodPost, http.MethodOptions} {
+			t.Run(method+" "+path, func(t *testing.T) {
+				req, requestErr := http.NewRequest(method, baseURL+path, nil)
+				require.NoError(t, requestErr)
+				resp, requestErr := client.Do(req)
+				require.NoError(t, requestErr)
+				defer func() { _ = resp.Body.Close() }()
+				assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+				assert.Equal(t, "GET, HEAD", resp.Header.Get("Allow"))
+			})
+		}
+	}
+}
+
 func TestLaunch_VersionEndpoint(t *testing.T) {
 	originalVersion := webhookversion.Version
 	originalCommit := webhookversion.Commit


### PR DESCRIPTION
## Summary

- restrict `/`, `/health`, `/livez`, `/readyz`, `/version`, and `/metrics` to GET and HEAD
- return 405 with `Allow: GET, HEAD` for other methods
- restrict Config UI pages and static assets to GET and HEAD
- add `Allow` headers to Config UI API method errors
- add runtime and handler regression coverage

## Why

The documentation and OpenAPI contract describe these resources as read-only GET endpoints, but several routes were registered with `app.All` and returned successful bodies for POST and OPTIONS requests.

## Validation

- `go test ./internal/server ./internal/configui ./internal/openapi -count=1`
- `go test -race ./internal/server ./internal/configui -run 'TestLaunch_ReadOnlyEndpointsRejectOtherMethods|TestLaunch_VersionEndpoint|TestHandler.*MethodNotAllowed|TestHandlerReadOnlyResourcesRejectOtherMethods' -count=1`
- `git diff --check`
