### PR TITLE
fix: align hook HTTP contract

### DIFF
--- a/docs/en-US/API-Reference.md
+++ b/docs/en-US/API-Reference.md
@@ -177,9 +177,9 @@ You can also print the spec to stdout at startup with `-openapi-print` (e.g. `./
 
 ### 8. Hook Execution Endpoint
 
-**Endpoint:** `POST|GET|PUT|DELETE /hooks/{hook-id}`
+**Endpoint:** `ANY /hooks/{hook-id}` by default; configurable per hook or with `-http-methods`
 
-**Description:** Execute a configured hook. The HTTP methods allowed depend on the hook configuration and the `-http-methods` flag.
+**Description:** Execute a configured hook. A hook-level `http-methods` list takes precedence over the `-http-methods` flag. When neither is configured, all standard HTTP methods accepted by the server are allowed for backward compatibility.
 
 **URL Parameters:**
 - `hook-id` (required): The ID of the hook to execute, as defined in your hooks configuration file.
@@ -208,23 +208,14 @@ The request body can contain:
   - Custom status code: As configured in `success-http-response-code` or `trigger-rule-mismatch-http-response-code`
 
 - **Content-Type:** 
-  - `text/plain` (default)
-  - `application/json` (if error occurs)
+  - `text/plain; charset=utf-8` for default success and error responses
   - As configured in `response-headers`
+
+- **405 response header:** `Allow` lists the methods configured for the matched hook.
 
 - **Response Body:**
   - Success: Custom message from `response-message`, command output (if `include-command-output-in-response` is enabled), or default message
-  - Error: JSON error response with details
-
-**Error Response Format:**
-```json
-{
-  "error": "Error Type",
-  "message": "Error message",
-  "request_id": "request-id-here",
-  "hook_id": "hook-id-here"
-}
-```
+  - Error: Plain-text compatibility message. Request and hook identifiers remain available in logs and tracing.
 
 **Example - Successful Execution:**
 ```bash
@@ -242,15 +233,7 @@ curl "http://localhost:9000/hooks/redeploy-webhook?branch=main&commit=abc123"
 curl -X POST http://localhost:9000/hooks/non-existent-hook
 ```
 
-**Response:**
-```json
-{
-  "error": "Not Found",
-  "message": "Hook not found.",
-  "request_id": "req-123",
-  "hook_id": "non-existent-hook"
-}
-```
+**Response:** `Hook not found.`
 
 **Example - Method Not Allowed:**
 ```bash
@@ -258,15 +241,9 @@ curl -X POST http://localhost:9000/hooks/non-existent-hook
 curl -X GET http://localhost:9000/hooks/post-only-hook
 ```
 
-**Response:**
-```json
-{
-  "error": "Method Not Allowed",
-  "message": "HTTP GET method not allowed for hook \"post-only-hook\"",
-  "request_id": "req-456",
-  "hook_id": "post-only-hook"
-}
-```
+**Response:** `HTTP GET method not allowed for hook "post-only-hook"`
+
+**Response header:** `Allow: POST`
 
 ---
 

--- a/docs/zh-CN/API-Reference.md
+++ b/docs/zh-CN/API-Reference.md
@@ -177,9 +177,9 @@ curl http://localhost:9000/openapi
 
 ### 8. Hook 执行端点
 
-**端点:** `POST|GET|PUT|DELETE /hooks/{hook-id}`
+**端点:** 默认支持 `ANY /hooks/{hook-id}`；可通过 hook 配置或 `-http-methods` 限制
 
-**描述:** 执行配置的 hook。允许的 HTTP 方法取决于 hook 配置和 `-http-methods` 标志。
+**描述:** 执行配置的 hook。hook 自身的 `http-methods` 优先于全局 `-http-methods`。两者均未配置时，为保持向后兼容，允许服务器支持的所有标准 HTTP 方法。
 
 **URL 参数:**
 - `hook-id` (必需): 要执行的 hook 的 ID，在您的 hooks 配置文件中定义。
@@ -208,23 +208,14 @@ curl http://localhost:9000/openapi
   - 自定义状态码: 在 `success-http-response-code` 或 `trigger-rule-mismatch-http-response-code` 中配置
 
 - **Content-Type:** 
-  - `text/plain` (默认)
-  - `application/json` (如果发生错误)
+  - 默认成功和错误响应均为 `text/plain; charset=utf-8`
   - 在 `response-headers` 中配置
+
+- **405 响应头:** `Allow` 列出匹配 hook 配置允许的方法。
 
 - **响应体:**
   - 成功: 来自 `response-message` 的自定义消息、命令输出（如果启用了 `include-command-output-in-response`）或默认消息
-  - 错误: 包含详细信息的 JSON 错误响应
-
-**错误响应格式:**
-```json
-{
-  "error": "错误类型",
-  "message": "错误消息",
-  "request_id": "请求-id-这里",
-  "hook_id": "hook-id-这里"
-}
-```
+  - 错误: 为兼容既有客户端返回纯文本消息；请求 ID 和 hook ID 仍可在日志及链路追踪中查询
 
 **示例 - 成功执行:**
 ```bash
@@ -242,15 +233,7 @@ curl "http://localhost:9000/hooks/redeploy-webhook?branch=main&commit=abc123"
 curl -X POST http://localhost:9000/hooks/non-existent-hook
 ```
 
-**响应:**
-```json
-{
-  "error": "Not Found",
-  "message": "Hook not found.",
-  "request_id": "req-123",
-  "hook_id": "non-existent-hook"
-}
-```
+**响应:** `Hook not found.`
 
 **示例 - 方法不允许:**
 ```bash
@@ -258,15 +241,9 @@ curl -X POST http://localhost:9000/hooks/non-existent-hook
 curl -X GET http://localhost:9000/hooks/post-only-hook
 ```
 
-**响应:**
-```json
-{
-  "error": "Method Not Allowed",
-  "message": "HTTP GET method not allowed for hook \"post-only-hook\"",
-  "request_id": "req-456",
-  "hook_id": "post-only-hook"
-}
-```
+**响应:** `HTTP GET method not allowed for hook "post-only-hook"`
+
+**响应头:** `Allow: POST`
 
 ---
 

--- a/internal/openapi/spec.go
+++ b/internal/openapi/spec.go
@@ -118,8 +118,9 @@ func op(summary, description, contentType string) map[string]any {
 
 func hooksPathOp(appFlags flags.AppFlags) map[string]any {
 	methods := appFlags.HttpMethods
+	allowAnyMethod := methods == ""
 	if methods == "" {
-		methods = "POST,PUT,PATCH"
+		methods = "GET,HEAD,POST,PUT,PATCH,DELETE,CONNECT,OPTIONS,TRACE"
 	}
 	parts := strings.Split(methods, ",")
 	for i, p := range parts {
@@ -130,8 +131,16 @@ func hooksPathOp(appFlags flags.AppFlags) map[string]any {
 	}
 
 	ops := make(map[string]any)
+	additionalMethods := make([]string, 0)
 	for _, m := range parts {
 		if m == "" {
+			continue
+		}
+		switch m {
+		case "GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "TRACE":
+			// OpenAPI 3.0 path-item operations.
+		default:
+			additionalMethods = append(additionalMethods, m)
 			continue
 		}
 		ops[strings.ToLower(m)] = map[string]any{
@@ -162,14 +171,42 @@ func hooksPathOp(appFlags flags.AppFlags) map[string]any {
 						"application/json": map[string]any{"schema": map[string]any{"type": "object"}},
 					},
 				},
-				"400": map[string]any{"description": "Bad request or hook rules not satisfied"},
-				"404": map[string]any{"description": "Hook not found"},
-				"405": map[string]any{"description": "Method not allowed for this hook"},
-				"500": map[string]any{"description": "Internal server error during hook execution"},
-				"503": map[string]any{"description": "Server shutting down"},
+				"400": plainTextResponse("Bad request or hook rules not satisfied"),
+				"404": plainTextResponse("Hook not found"),
+				"405": methodNotAllowedResponse(),
+				"408": plainTextResponse("Hook execution timed out"),
+				"429": plainTextResponse("Rate limit exceeded"),
+				"500": plainTextResponse("Internal server error during hook execution"),
+				"503": plainTextResponse("Server shutting down"),
 			},
 		}
 	}
+	if len(additionalMethods) > 0 {
+		ops["x-webhook-additional-methods"] = additionalMethods
+	}
+	if allowAnyMethod {
+		ops["x-webhook-allow-any-method"] = true
+	}
 
 	return ops
+}
+
+func plainTextResponse(description string) map[string]any {
+	return map[string]any{
+		"description": description,
+		"content": map[string]any{
+			"text/plain": map[string]any{"schema": map[string]any{"type": "string"}},
+		},
+	}
+}
+
+func methodNotAllowedResponse() map[string]any {
+	response := plainTextResponse("Method not allowed for this hook")
+	response["headers"] = map[string]any{
+		"Allow": map[string]any{
+			"description": "Methods configured for the matched hook.",
+			"schema":      map[string]any{"type": "string"},
+		},
+	}
+	return response
 }

--- a/internal/openapi/spec.go
+++ b/internal/openapi/spec.go
@@ -139,8 +139,13 @@ func hooksPathOp(appFlags flags.AppFlags) map[string]any {
 		switch m {
 		case "GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "TRACE":
 			// OpenAPI 3.0 path-item operations.
-		default:
+		case "CONNECT":
+			// Fiber routes CONNECT requests, but OpenAPI 3.0 has no CONNECT operation key.
 			additionalMethods = append(additionalMethods, m)
+			continue
+		default:
+			// Fiber returns 501 for methods outside its configured request-method list.
+			// Do not advertise methods that cannot reach the hook handler.
 			continue
 		}
 		ops[strings.ToLower(m)] = map[string]any{

--- a/internal/openapi/spec_test.go
+++ b/internal/openapi/spec_test.go
@@ -81,6 +81,59 @@ func TestSpec_WithServerURL(t *testing.T) {
 	assert.Equal(t, "https://example.com", srv["url"])
 }
 
+func TestSpec_DefaultHookMethodsMatchRuntime(t *testing.T) {
+	out, err := Spec(flags.AppFlags{HooksURLPrefix: "hooks"}, "")
+	require.NoError(t, err)
+
+	var spec map[string]any
+	require.NoError(t, json.Unmarshal(out, &spec))
+	paths, ok := spec["paths"].(map[string]any)
+	require.True(t, ok)
+	hookPath, ok := paths["/hooks/{id}"].(map[string]any)
+	require.True(t, ok)
+
+	for _, method := range []string{"get", "head", "post", "put", "patch", "delete", "options", "trace"} {
+		assert.Contains(t, hookPath, method)
+	}
+	assert.Equal(t, []any{"CONNECT"}, hookPath["x-webhook-additional-methods"])
+	assert.Equal(t, true, hookPath["x-webhook-allow-any-method"])
+}
+
+func TestSpec_CustomNonOpenAPIMethodUsesExtension(t *testing.T) {
+	out, err := Spec(flags.AppFlags{HooksURLPrefix: "hooks", HttpMethods: "POST,CONNECT,CUSTOM"}, "")
+	require.NoError(t, err)
+
+	var spec map[string]any
+	require.NoError(t, json.Unmarshal(out, &spec))
+	paths := spec["paths"].(map[string]any)
+	hookPath := paths["/hooks/{id}"].(map[string]any)
+	assert.Contains(t, hookPath, "post")
+	assert.NotContains(t, hookPath, "connect")
+	assert.NotContains(t, hookPath, "custom")
+	assert.Equal(t, []any{"CONNECT", "CUSTOM"}, hookPath["x-webhook-additional-methods"])
+}
+
+func TestSpec_HookErrorsDescribePlainTextAndAllowHeader(t *testing.T) {
+	out, err := Spec(flags.AppFlags{HooksURLPrefix: "hooks", HttpMethods: "POST"}, "")
+	require.NoError(t, err)
+
+	var spec map[string]any
+	require.NoError(t, json.Unmarshal(out, &spec))
+	paths := spec["paths"].(map[string]any)
+	hookPath := paths["/hooks/{id}"].(map[string]any)
+	post := hookPath["post"].(map[string]any)
+	responses := post["responses"].(map[string]any)
+
+	for _, status := range []string{"400", "404", "405", "408", "429", "500", "503"} {
+		response := responses[status].(map[string]any)
+		content := response["content"].(map[string]any)
+		assert.Contains(t, content, "text/plain")
+	}
+	methodNotAllowed := responses["405"].(map[string]any)
+	headers := methodNotAllowed["headers"].(map[string]any)
+	assert.Contains(t, headers, "Allow")
+}
+
 func TestSpec_CustomURLPrefix(t *testing.T) {
 	appFlags := flags.AppFlags{
 		HooksURLPrefix: "api/webhooks",

--- a/internal/openapi/spec_test.go
+++ b/internal/openapi/spec_test.go
@@ -99,7 +99,7 @@ func TestSpec_DefaultHookMethodsMatchRuntime(t *testing.T) {
 	assert.Equal(t, true, hookPath["x-webhook-allow-any-method"])
 }
 
-func TestSpec_CustomNonOpenAPIMethodUsesExtension(t *testing.T) {
+func TestSpec_OnlyRoutableNonOpenAPIMethodUsesExtension(t *testing.T) {
 	out, err := Spec(flags.AppFlags{HooksURLPrefix: "hooks", HttpMethods: "POST,CONNECT,CUSTOM"}, "")
 	require.NoError(t, err)
 
@@ -110,7 +110,18 @@ func TestSpec_CustomNonOpenAPIMethodUsesExtension(t *testing.T) {
 	assert.Contains(t, hookPath, "post")
 	assert.NotContains(t, hookPath, "connect")
 	assert.NotContains(t, hookPath, "custom")
-	assert.Equal(t, []any{"CONNECT", "CUSTOM"}, hookPath["x-webhook-additional-methods"])
+	assert.Equal(t, []any{"CONNECT"}, hookPath["x-webhook-additional-methods"])
+}
+
+func TestSpec_DoesNotAdvertiseUnroutableCustomMethod(t *testing.T) {
+	out, err := Spec(flags.AppFlags{HooksURLPrefix: "hooks", HttpMethods: "CUSTOM"}, "")
+	require.NoError(t, err)
+
+	var spec map[string]any
+	require.NoError(t, json.Unmarshal(out, &spec))
+	paths := spec["paths"].(map[string]any)
+	hookPath := paths["/hooks/{id}"].(map[string]any)
+	assert.NotContains(t, hookPath, "x-webhook-additional-methods")
 }
 
 func TestSpec_HookErrorsDescribePlainTextAndAllowHeader(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -151,7 +151,7 @@ func allowedHTTPMethods(h *hook.Hook, appFlags flags.AppFlags) []string {
 // isMethodAllowed 检查 HTTP 方法是否被允许。
 func isMethodAllowed(method string, h *hook.Hook, appFlags flags.AppFlags) bool {
 	allowedMethods := allowedHTTPMethods(h, appFlags)
-	if len(allowedMethods) == 0 {
+	if allowedMethods == nil {
 		return true
 	}
 	for _, allowed := range allowedMethods {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -122,32 +122,44 @@ func (trw *trackingResponseWriter) Flush() {
 	}
 }
 
-// isMethodAllowed 检查 HTTP 方法是否被允许
-// 优先级：hook 的 HTTPMethods > appFlags.HttpMethods > 默认允许所有方法
-func isMethodAllowed(method string, h *hook.Hook, appFlags flags.AppFlags) bool {
+// allowedHTTPMethods 返回 hook 的有效方法契约。
+// 优先级：hook 的 HTTPMethods > appFlags.HttpMethods > 默认不限制方法。
+// nil 表示为保持向后兼容而允许任意方法。
+func allowedHTTPMethods(h *hook.Hook, appFlags flags.AppFlags) []string {
 	// 如果 hook 配置了允许的方法，优先使用 hook 的配置
 	// HTTP 方法已在配置加载时清理和验证，直接比较即可
 	if len(h.HTTPMethods) != 0 {
-		for i := range h.HTTPMethods {
-			if method == h.HTTPMethods[i] {
-				return true
-			}
-		}
-		return false
+		return h.HTTPMethods
 	}
 
 	// 如果应用配置了默认允许的方法，使用应用配置
 	if appFlags.HttpMethods != "" {
-		for _, v := range strings.Split(appFlags.HttpMethods, ",") {
-			if method == v {
-				return true
+		parts := strings.Split(appFlags.HttpMethods, ",")
+		methods := make([]string, 0, len(parts))
+		for _, method := range parts {
+			method = strings.TrimSpace(strings.ToUpper(method))
+			if method != "" {
+				methods = append(methods, method)
 			}
 		}
-		return false
+		return methods
 	}
 
-	// 默认允许所有方法
-	return true
+	return nil
+}
+
+// isMethodAllowed 检查 HTTP 方法是否被允许。
+func isMethodAllowed(method string, h *hook.Hook, appFlags flags.AppFlags) bool {
+	allowedMethods := allowedHTTPMethods(h, appFlags)
+	if len(allowedMethods) == 0 {
+		return true
+	}
+	for _, allowed := range allowedMethods {
+		if method == allowed {
+			return true
+		}
+	}
+	return false
 }
 
 // setResponseHeaders 设置响应头
@@ -686,6 +698,7 @@ func createHookHandler(appFlags flags.AppFlags, srv *Server) func(w http.Respons
 			err := NewHTTPError(ErrorTypeClient, http.StatusMethodNotAllowed,
 				fmt.Sprintf("HTTP %s method not allowed for hook %q", r.Method, hookID), nil)
 			statusCode = err.Status
+			wrappedWriter.Header().Set("Allow", strings.Join(allowedHTTPMethods(matchedHook, appFlags), ", "))
 			HandleErrorPlain(wrappedWriter, err, requestID, hookID)
 			// 记录审计日志：HTTP 方法不允许
 			audit.LogMethodNotAllowed(requestID, hookID, r.RemoteAddr, r.UserAgent(), r.Method)

--- a/internal/server/webhook_test.go
+++ b/internal/server/webhook_test.go
@@ -1162,6 +1162,13 @@ func TestIsMethodAllowed(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:     "explicit appFlags methods normalize to empty",
+			method:   "POST",
+			hook:     &hook.Hook{},
+			appFlags: flags.AppFlags{HttpMethods: ","},
+			expected: false,
+		},
+		{
 			name:     "default allow all",
 			method:   "ANY",
 			hook:     &hook.Hook{},

--- a/internal/server/webhook_test.go
+++ b/internal/server/webhook_test.go
@@ -212,6 +212,7 @@ func TestCreateHookHandler_MethodNotAllowed(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+	assert.Equal(t, "POST", resp.Header.Get("Allow"))
 }
 
 func TestCreateHookHandler_AppFlagsHttpMethods(t *testing.T) {
@@ -244,6 +245,7 @@ func TestCreateHookHandler_AppFlagsHttpMethods(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = resp2.Body.Close() }()
 	assert.Equal(t, http.StatusMethodNotAllowed, resp2.StatusCode)
+	assert.Equal(t, "POST, PUT", resp2.Header.Get("Allow"))
 }
 
 func TestHandleHook_StreamOutput(t *testing.T) {


### PR DESCRIPTION
## Summary

- return an accurate `Allow` header when a matched hook rejects an HTTP method
- preserve the existing precedence: hook methods, global methods, then unrestricted compatibility mode
- make OpenAPI describe every representable method accepted by unrestricted mode
- expose CONNECT and custom methods through OpenAPI vendor extensions instead of invalid path-item keys
- describe hook 4xx/5xx responses as the actual plain-text compatibility responses
- add the previously omitted 408 and 429 responses
- align English and Chinese API references with runtime behavior

## Compatibility

This does not narrow the default hook method behavior. When neither hook-level `http-methods` nor `-http-methods` is configured, arbitrary methods remain allowed as before.

## Validation

- `go test ./internal/server ./internal/openapi -count=1`
- `go test -race ./internal/server ./internal/openapi -run 'TestCreateHookHandler_MethodNotAllowed|TestCreateHookHandler_AppFlagsHttpMethods|TestIsMethodAllowed|TestSpec_' -count=1`
- `git diff --check`
