### PR TITLE
fix: inject release branch metadata

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,6 +10,7 @@ builds:
           -X "github.com/soulteary/webhook/internal/version.Version={{ .Tag }}"
           -X "github.com/soulteary/webhook/internal/version.Commit={{ .FullCommit }}"
           -X "github.com/soulteary/webhook/internal/version.BuildDate={{ .Date }}"
+          -X "github.com/soulteary/webhook/internal/version.Branch={{ .Branch }}"
     id: macos
     goos: [darwin]
     goarch: [amd64, arm64]

--- a/release_metadata_test.go
+++ b/release_metadata_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/invopop/yaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGoReleaserInjectsCompleteVersionMetadata(t *testing.T) {
+	data, err := os.ReadFile(".goreleaser.yaml")
+	require.NoError(t, err)
+
+	var config struct {
+		Builds []struct {
+			ID      string   `json:"id"`
+			LDFlags []string `json:"ldflags"`
+		} `json:"builds"`
+	}
+	require.NoError(t, yaml.Unmarshal(data, &config))
+	require.NotEmpty(t, config.Builds)
+
+	required := []string{
+		"internal/version.Version={{ .Tag }}",
+		"internal/version.Commit={{ .FullCommit }}",
+		"internal/version.BuildDate={{ .Date }}",
+		"internal/version.Branch={{ .Branch }}",
+	}
+	for _, build := range config.Builds {
+		joined := strings.Join(build.LDFlags, " ")
+		for _, value := range required {
+			assert.Contains(t, joined, value, "build %q must inject complete version metadata", build.ID)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- inject GoReleaser's `.Branch` template value into `internal/version.Branch`
- add a parsed GoReleaser configuration test that requires version, commit, build date, and branch metadata for every build target

## Why

PR #168 added version, commit, and build-date injection, but official GoReleaser artifacts could still omit `branch` and `X-Branch`. GoReleaser documents `.Branch` as a common template field, so release binaries can populate the complete version response consistently.

Existing 7.1.0 artifacts remain immutable; this applies to newly built releases.

## Validation

- `go test . ./internal/version ./internal/server -run 'TestGoReleaserInjectsCompleteVersionMetadata|TestGetVersionInfo|TestLaunch_VersionEndpoint' -count=1`
- parsed `.goreleaser.yaml` through the repository's YAML dependency
- `git diff --check`
