### PR TITLE
fix: close P0 security and release trust gaps

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,67 @@
+name: Benchmarks
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/benchmark.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/benchmark.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: benchmarks-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Record environment
+        run: |
+          {
+            go version
+            git rev-parse HEAD
+            uname -a
+            lscpu
+          } | tee benchmark-environment.txt
+
+      - name: Run reproducible benchmark sample
+        run: |
+          go test -run='^$' \
+            -bench='Benchmark(HookExecution|ConcurrentHookExecution)$' \
+            -benchmem -count=5 ./internal/server | tee benchmark.txt
+          {
+            echo '## Hook execution benchmarks'
+            echo '```text'
+            cat benchmark.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: benchmark-${{ github.sha }}
+          path: |
+            benchmark.txt
+            benchmark-environment.txt
+          if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,26 +15,28 @@ env:
 permissions:
   contents: write
   packages: write
+  id-token: write
+  attestations: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Cache Go modules
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -48,24 +50,45 @@ jobs:
 
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install Syft
+        if: success() && startsWith(github.ref, 'refs/tags/')
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          syft-version: v1.51.1
+
+      - name: Install Cosign
+        if: success() && startsWith(github.ref, 'refs/tags/')
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+        with:
+          cosign-release: v3.1.3
+
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         if: success() && startsWith(github.ref, 'refs/tags/')
         with:
-          version: latest
+          version: v2.18.0
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attest release artifacts
+        if: success() && startsWith(github.ref, 'refs/tags/')
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
+        with:
+          subject-path: |
+            dist/*.tar.gz
+            dist/*_checksums.txt
+            dist/*.sbom.json

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,15 +40,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@6f5948dfacef28e207b48d0905cf90c03365536d # v3
         with:
           languages: ${{ matrix.language }}
           config: |
@@ -61,9 +61,9 @@ jobs:
                     - go/clear-text-logging
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@6f5948dfacef28e207b48d0905cf90c03365536d # v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@6f5948dfacef28e207b48d0905cf90c03365536d # v3
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -18,18 +18,27 @@ on:
 
 jobs:
   scan:
-    permissions: write-all
+    permissions:
+      contents: read
+      security-events: write
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - name: Security Scan
-        uses: securego/gosec@master
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          args: "-no-fail -fmt sarif -out results.sarif -exclude=G204 ./..."
+          go-version-file: go.mod
+
+      - name: Vulnerability scan
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...
+
+      - name: Security scan
+        run: go run github.com/securego/gosec/v2/cmd/gosec@v2.29.0 -fmt sarif -out results.sarif -exclude=G204 ./...
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+        if: always() && hashFiles('results.sarif') != ''
+        uses: github/codeql-action/upload-sarif@6f5948dfacef28e207b48d0905cf90c03365536d # v3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -32,7 +32,9 @@ jobs:
           go-version-file: go.mod
 
       - name: Vulnerability scan
-        run: go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...
+        # v1.1.4 predates Go 1.27 and panics while building SSA. Pin the first
+        # upstream revision tested against the Go 1.27 toolchain instead.
+        run: go run golang.org/x/vuln/cmd/govulncheck@8fcedea455d953a0f8470e1f41420bb6f2e72665 ./...
 
       - name: Security scan
         run: go run github.com/securego/gosec/v2/cmd/gosec@v2.29.0 -fmt sarif -out results.sarif -exclude=G204 ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,15 +21,15 @@ jobs:
       GO111MODULE: on
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
 
       - name: Cache Go modules
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -37,4 +37,4 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Run tests
-        run: go test ./...
+        run: go test -race ./...

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 project_name: webhook
 
 builds:
@@ -263,3 +264,28 @@ docker_manifests:
       - "ghcr.io/soulteary/webhook:linux-armv7-{{ .Tag }}"
       - "ghcr.io/soulteary/webhook:linux-armv6-{{ .Tag }}"
     skip_push: "false"
+
+# Generate an SPDX SBOM for every release archive. SBOMs are included in the
+# checksum file and uploaded as release assets by GoReleaser.
+sboms:
+  - artifacts: archive
+
+# Keyless Sigstore signature for the checksum file and all files it covers.
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sigstore.json"
+    artifacts: checksum
+    args:
+      - sign-blob
+      - "--bundle=${signature}"
+      - "${artifact}"
+      - --yes
+
+# Sign the published multi-architecture image manifests by immutable digest.
+docker_signs:
+  - cmd: cosign
+    artifacts: manifests
+    args:
+      - sign
+      - "${artifact}@${digest}"
+      - --yes

--- a/README-zhCN.md
+++ b/README-zhCN.md
@@ -1,11 +1,11 @@
 # 什么是 WebHook (歪脖虎克)?
 
-[![Release](https://github.com/soulteary/webhook/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/soulteary/webhook/actions/workflows/build.yml) [![CodeQL](https://github.com/soulteary/webhook/actions/workflows/codeql.yml/badge.svg)](https://github.com/soulteary/webhook/actions/workflows/codeql.yml) [![Security Scan](https://github.com/soulteary/webhook/actions/workflows/scan.yml/badge.svg)](https://github.com/soulteary/webhook/actions/workflows/scan.yml) [![Go Report Card](.github/goreportcard.svg)](.github/goreportcard-report.md)
+[![Release](https://github.com/soulteary/webhook/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/soulteary/webhook/actions/workflows/build.yml) [![CodeQL](https://github.com/soulteary/webhook/actions/workflows/codeql.yml/badge.svg)](https://github.com/soulteary/webhook/actions/workflows/codeql.yml) [![Security Scan](https://github.com/soulteary/webhook/actions/workflows/scan.yml/badge.svg)](https://github.com/soulteary/webhook/actions/workflows/scan.yml) [![Benchmarks](https://github.com/soulteary/webhook/actions/workflows/benchmark.yml/badge.svg?branch=main)](https://github.com/soulteary/webhook/actions/workflows/benchmark.yml) [![Go Report Card](.github/goreportcard.svg)](.github/goreportcard-report.md)
 
 
  <img src="./docs/logo/logo-600x600.jpg" alt="Webhook" align="left" width="180" />
  
- **WebHook（歪脖虎克）** 是一个用 Go 语言编写的轻量、安全、高度可配置的 HTTP Webhook 服务器。它允许你创建 HTTP 端点来触发自定义命令或脚本，非常适合自动化部署、CI/CD 流水线以及各种服务集成。
+ **WebHook（歪脖虎克）** 是面向自托管、边缘节点和内网环境的安全、可观测 webhook-to-command runner。它以兼容 [adnanh/webhook](https://github.com/adnanh/webhook) Hook 配置为目标，并补充命令执行、流量、审计与链路追踪方面的生产控制能力。
 
 ## ✨ 核心特性
 
@@ -37,6 +37,15 @@ WebHook 遵循简单、专注的方法：
 
 你执行的命令完全由你决定——从简单脚本到复杂的自动化工作流。
 
+## 兼容性与产品边界
+
+| 范围 | 兼容性 / 行为 |
+|---|---|
+| Hook 配置 | 以兼容 adnanh/webhook 的 JSON/YAML 配置为目标，通常可直接加载；每次升级前仍应执行校验。 |
+| 历史默认行为 | 默认 `compat` Profile 保持现有的宽松 HTTP 方法与安全能力按需开启的行为。 |
+| 生产安全默认值 | `-profile secure` 默认启用仅 POST、严格参数检查、限流、请求 ID 和审计日志，并强制要求 `-allowed-command-paths`。 |
+| 明确边界 | WebHook 负责受控执行本地命令，不承诺持久队列、重试、DLQ 或进程重启后的任务恢复。 |
+
 # 🚀 快速开始
 
 几分钟内即可上手使用 WebHook。
@@ -47,7 +56,7 @@ WebHook 遵循简单、专注的方法：
 
 [![](.github/release.png)](https://github.com/soulteary/webhook/releases)
 
-从 [发布页面](https://github.com/soulteary/webhook/releases) 下载适用于 Linux、macOS 和 Windows 的预编译二进制文件。
+从 [发布页面](https://github.com/soulteary/webhook/releases) 下载适用于 Linux 和 macOS 的预编译二进制文件。
 
 ### 方式二：Docker
 
@@ -63,6 +72,8 @@ docker pull soulteary/webhook:7.1.0
 # 包含调试工具的扩展版本
 docker pull soulteary/webhook:extend-7.1.0
 ```
+
+两种 Release 镜像都以非 root 用户从 `/var/lib/webhook` 运行。默认镜像是基于 `scratch` 的 Core 镜像，适合挂载静态可执行文件且不依赖 Shell 的配置；`extend-*` 镜像包含 Alpine、Bash、curl、wget、jq 和 yq，适合执行 Shell 脚本。请确保挂载的 Hook、命令和审计目录可由 UID/GID `65532` 读取或写入。
 
 ### 方式三：从源码构建
 
@@ -122,20 +133,21 @@ http://yourserver:9000/hooks/redeploy-webhook
 
 **重要提示**：上面的示例没有身份验证。在生产环境中请始终使用触发规则！
 
-**示例：带密钥令牌的安全钩子**
+**示例：使用 HMAC 请求头的安全钩子**
 
 ```json
 [
   {
     "id": "secure-deploy",
     "execute-command": "/var/scripts/deploy.sh",
+    "http-methods": ["POST"],
     "trigger-rule": {
       "match": {
-        "type": "value",
-        "value": "your-secret-token",
+        "type": "payload-hmac-sha256",
+        "secret": "replace-with-a-long-random-secret",
         "parameter": {
-          "source": "url",
-          "name": "token"
+          "source": "header",
+          "name": "X-Webhook-Signature"
         }
       }
     }
@@ -143,7 +155,15 @@ http://yourserver:9000/hooks/redeploy-webhook
 ]
 ```
 
-现在钩子只能通过以下方式触发：`http://yourserver:9000/hooks/secure-deploy?token=your-secret-token`
+使用 Secure Profile 启动（该 Profile 强制要求命令白名单）：
+
+```bash
+./webhook -profile secure \
+  -allowed-command-paths=/var/scripts \
+  -hooks hooks.json
+```
+
+发送原始请求体时提供 `X-Webhook-Signature: sha256=<HMAC-SHA256 十六进制值>`。建议通过[配置模板](docs/zh-CN/Templates.md)从环境变量读取密钥，避免将其提交到仓库。与 URL 查询参数 Token 不同，签名不会被复制到 URL、访问日志或浏览器历史中。
 
 更多安全选项，请查看：
 - [安全最佳实践](docs/zh-CN/Security-Best-Practices.md) - 全面的安全指南
@@ -184,6 +204,20 @@ http://yourserver:9000/hooks/redeploy-webhook
 
 ### 安全
 - [安全策略](SECURITY.md) - 安全功能和漏洞报告
+
+### Release 完整性
+
+Tag Release 会发布 SPDX SBOM、Checksum 文件的 Keyless Sigstore Bundle、已签名的多架构容器 Manifest，以及 GitHub 构建来源证明。验证示例：
+
+```bash
+gh attestation verify webhook_7.1.0_linux_amd64.tar.gz -R soulteary/webhook
+
+cosign verify-blob \
+  --bundle webhook_7.1.0_checksums.txt.sigstore.json \
+  --certificate-identity-regexp='^https://github.com/soulteary/webhook/.github/workflows/build.yml@refs/tags/.+$' \
+  --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
+  webhook_7.1.0_checksums.txt
+```
 
 ## 关于此 Fork
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Welcome to WebHook! [中文文档](./README-zhCN.md)
 
-[![Release](https://github.com/soulteary/webhook/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/soulteary/webhook/actions/workflows/build.yml) [![CodeQL](https://github.com/soulteary/webhook/actions/workflows/codeql.yml/badge.svg)](https://github.com/soulteary/webhook/actions/workflows/codeql.yml) [![Security Scan](https://github.com/soulteary/webhook/actions/workflows/scan.yml/badge.svg)](https://github.com/soulteary/webhook/actions/workflows/scan.yml) [![Go Report Card](.github/goreportcard.svg)](.github/goreportcard-report.md)
+[![Release](https://github.com/soulteary/webhook/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/soulteary/webhook/actions/workflows/build.yml) [![CodeQL](https://github.com/soulteary/webhook/actions/workflows/codeql.yml/badge.svg)](https://github.com/soulteary/webhook/actions/workflows/codeql.yml) [![Security Scan](https://github.com/soulteary/webhook/actions/workflows/scan.yml/badge.svg)](https://github.com/soulteary/webhook/actions/workflows/scan.yml) [![Benchmarks](https://github.com/soulteary/webhook/actions/workflows/benchmark.yml/badge.svg?branch=main)](https://github.com/soulteary/webhook/actions/workflows/benchmark.yml) [![Go Report Card](.github/goreportcard.svg)](.github/goreportcard-report.md)
 
 
  <img src="./docs/logo/logo-600x600.jpg" alt="Webhook" align="left" width="180" />
  
- **WebHook** is a lightweight, secure, and highly configurable HTTP webhook server written in Go. It enables you to create HTTP endpoints that trigger custom commands or scripts based on incoming requests, making it perfect for automating deployments, CI/CD pipelines, and integrating with various services.
+ **WebHook** is a hardened and observable webhook-to-command runner for self-hosted, edge, and private-network environments. It keeps compatibility with [adnanh/webhook](https://github.com/adnanh/webhook) hook definitions while adding production controls for command execution, traffic, auditing, and telemetry.
 
 ## ✨ Key Features
 
@@ -37,6 +37,15 @@ WebHook follows a simple, focused approach:
 
 The commands you execute are entirely up to you - from simple scripts to complex automation workflows.
 
+## Compatibility and Scope
+
+| Area | Compatibility / behavior |
+|---|---|
+| Hook definitions | Existing adnanh/webhook JSON and YAML definitions are a compatibility target and should normally load unchanged. Validate before every upgrade. |
+| Historical defaults | The default `compat` profile preserves the existing permissive HTTP-method and opt-in security behavior. |
+| Production defaults | `-profile secure` enables POST-only hooks, strict argument checks, rate limiting, request IDs, and audit logging; it also requires `-allowed-command-paths`. |
+| Deliberate boundary | WebHook controls local command execution. It is not a durable delivery platform and does not promise persistent queues, retries, DLQs, or restart recovery. |
+
 # 🚀 Quick Start
 
 Get up and running with WebHook in minutes.
@@ -47,7 +56,7 @@ Get up and running with WebHook in minutes.
 
 [![](.github/release.png)](https://github.com/soulteary/webhook/releases)
 
-Download pre-built binaries for Linux, macOS, and Windows from the [Releases page](https://github.com/soulteary/webhook/releases).
+Download pre-built binaries for Linux and macOS from the [Releases page](https://github.com/soulteary/webhook/releases).
 
 ### Option 2: Docker
 
@@ -63,6 +72,8 @@ docker pull soulteary/webhook:7.1.0
 # Extended version with debugging tools
 docker pull soulteary/webhook:extend-7.1.0
 ```
+
+Both release variants run as non-root from `/var/lib/webhook`. The default image is a `scratch`-based core image: use it for mounted static executables and configurations that do not need a shell. The `extend-*` image includes Alpine, Bash, curl, wget, jq, and yq and is the appropriate variant for shell-script hooks. Ensure mounted hooks, commands, and audit paths are readable or writable by UID/GID `65532`.
 
 ### Option 3: Build from Source
 
@@ -122,20 +133,21 @@ Single-file mode is still supported when explicitly set:
 
 **Important**: The example above has no authentication. Always use trigger rules in production!
 
-**Example: Secure Hook with Secret Token**
+**Example: Secure Hook with an HMAC Header**
 
 ```json
 [
   {
     "id": "secure-deploy",
     "execute-command": "/var/scripts/deploy.sh",
+    "http-methods": ["POST"],
     "trigger-rule": {
       "match": {
-        "type": "value",
-        "value": "your-secret-token",
+        "type": "payload-hmac-sha256",
+        "secret": "replace-with-a-long-random-secret",
         "parameter": {
-          "source": "url",
-          "name": "token"
+          "source": "header",
+          "name": "X-Webhook-Signature"
         }
       }
     }
@@ -143,7 +155,15 @@ Single-file mode is still supported when explicitly set:
 ]
 ```
 
-Now the hook can only be triggered with: `http://yourserver:9000/hooks/secure-deploy?token=your-secret-token`
+Start with the secure profile (the command allowlist is mandatory for this profile):
+
+```bash
+./webhook -profile secure \
+  -allowed-command-paths=/var/scripts \
+  -hooks hooks.json
+```
+
+Send the exact request body with `X-Webhook-Signature: sha256=<hex HMAC-SHA256>`. Prefer loading the secret from an environment variable through a [configuration template](docs/en-US/Templates.md) instead of committing it. Unlike query-string tokens, the signature is not copied into URLs, access logs, or browser history.
 
 For more security options, see:
 - [Security Best Practices](docs/en-US/Security-Best-Practices.md) - Comprehensive security guide
@@ -184,6 +204,20 @@ For more examples and use cases, check out [Hook Examples](docs/en-US/Hook-Examp
 
 ### Security
 - [Security Policy](SECURITY.md) - Security features and vulnerability reporting
+
+### Release Integrity
+
+Tagged releases publish SPDX SBOMs, a keyless Sigstore bundle for the checksum file, signed multi-architecture container manifests, and GitHub build-provenance attestations. Examples:
+
+```bash
+gh attestation verify webhook_7.1.0_linux_amd64.tar.gz -R soulteary/webhook
+
+cosign verify-blob \
+  --bundle webhook_7.1.0_checksums.txt.sigstore.json \
+  --certificate-identity-regexp='^https://github.com/soulteary/webhook/.github/workflows/build.yml@refs/tags/.+$' \
+  --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
+  webhook_7.1.0_checksums.txt
+```
 
 ## About This Fork
 

--- a/ci_security_test.go
+++ b/ci_security_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitHubActionsArePinned(t *testing.T) {
+	workflows, err := filepath.Glob(".github/workflows/*.yml")
+	require.NoError(t, err)
+	require.NotEmpty(t, workflows)
+
+	usesPattern := regexp.MustCompile(`(?m)^\s*(?:-\s*)?uses:\s*[^\s#]+@([^\s#]+)`)
+	shaPattern := regexp.MustCompile(`^[0-9a-f]{40}$`)
+	for _, workflow := range workflows {
+		data, err := os.ReadFile(workflow)
+		require.NoError(t, err)
+		for _, match := range usesPattern.FindAllStringSubmatch(string(data), -1) {
+			assert.Regexp(t, shaPattern, match[1], "%s contains an unpinned action: %s", workflow, match[0])
+		}
+	}
+}
+
+func TestSecurityWorkflowFailsClosed(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/scan.yml")
+	require.NoError(t, err)
+	contents := string(data)
+
+	assert.NotContains(t, contents, "write-all")
+	assert.NotContains(t, contents, "@master")
+	assert.NotContains(t, contents, "-no-fail")
+	assert.Contains(t, contents, "govulncheck@v1.1.4")
+	assert.Contains(t, contents, "gosec@v2.29.0")
+}
+
+func TestPrimaryTestWorkflowUsesRaceDetector(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/test.yml")
+	require.NoError(t, err)
+	assert.True(t, strings.Contains(string(data), "go test -race ./..."))
+}
+
+func TestReleaseWorkflowPinsSupplyChainTools(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/build.yml")
+	require.NoError(t, err)
+	contents := string(data)
+
+	assert.Contains(t, contents, "syft-version: v1.51.1")
+	assert.Contains(t, contents, "cosign-release: v3.1.3")
+	assert.Contains(t, contents, "version: v2.18.0")
+	assert.Contains(t, contents, "actions/attest@")
+	assert.Contains(t, contents, "id-token: write")
+	assert.Contains(t, contents, "attestations: write")
+}

--- a/ci_security_test.go
+++ b/ci_security_test.go
@@ -35,7 +35,7 @@ func TestSecurityWorkflowFailsClosed(t *testing.T) {
 	assert.NotContains(t, contents, "write-all")
 	assert.NotContains(t, contents, "@master")
 	assert.NotContains(t, contents, "-no-fail")
-	assert.Contains(t, contents, "govulncheck@v1.1.4")
+	assert.Contains(t, contents, "govulncheck@8fcedea455d953a0f8470e1f41420bb6f2e72665")
 	assert.Contains(t, contents, "gosec@v2.29.0")
 }
 

--- a/docker/goreleaser/Dockerfile
+++ b/docker/goreleaser/Dockerfile
@@ -1,9 +1,13 @@
-FROM alpine:3.19.0 as builder
-RUN apk --update add ca-certificates
+FROM alpine:3.24.1 AS certificates
+RUN apk add --no-cache ca-certificates && \
+    mkdir -p /var/lib/webhook/hooks
 
 FROM scratch
 LABEL maintainer "soulteary <soulteary@gmail.com>"
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY webhook /usr/bin/webhook
+COPY --from=certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=certificates --chown=65532:65532 /var/lib/webhook /var/lib/webhook
+COPY --chown=65532:65532 webhook /usr/bin/webhook
+USER 65532:65532
+WORKDIR /var/lib/webhook
 EXPOSE 9000/tcp
-CMD ["/usr/bin/webhook"]
+ENTRYPOINT ["/usr/bin/webhook"]

--- a/docker/goreleaser/Dockerfile.extend
+++ b/docker/goreleaser/Dockerfile.extend
@@ -1,10 +1,12 @@
-FROM alpine:3.19.0 as builder
-RUN apk --update add ca-certificates
-
-FROM alpine:3.19.0
+FROM alpine:3.24.1
 LABEL maintainer "soulteary <soulteary@gmail.com>"
-RUN apk --update add bash curl wget jq yq
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY webhook /usr/bin/webhook
+RUN apk add --no-cache bash ca-certificates curl wget jq yq && \
+    addgroup -S -g 65532 webhook && \
+    adduser -S -D -H -u 65532 -G webhook webhook && \
+    mkdir -p /var/lib/webhook/hooks && \
+    chown -R webhook:webhook /var/lib/webhook
+COPY --chown=webhook:webhook webhook /usr/bin/webhook
+USER webhook:webhook
+WORKDIR /var/lib/webhook
 EXPOSE 9000/tcp
-CMD ["/usr/bin/webhook"]
+ENTRYPOINT ["/usr/bin/webhook"]

--- a/docker/manual/Dockerfile
+++ b/docker/manual/Dockerfile
@@ -17,16 +17,20 @@ RUN go build -ldflags "-w -s \
     -X github.com/soulteary/webhook/internal/version.BuildDate=${BUILD_DATE} \
     -X github.com/soulteary/webhook/internal/version.Branch=${BRANCH}" -o webhook .
 
-FROM debian:bullseye-slim
+FROM debian:trixie-slim
 LABEL maintainer "soulteary <soulteary@gmail.com>"
 # 安装 CA 证书（用于 HTTPS 请求）
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 # 创建非 root 用户
-RUN groupadd -r webhook && useradd -r -g webhook webhook
+RUN groupadd -r webhook && \
+    useradd -r -g webhook -d /var/lib/webhook webhook && \
+    mkdir -p /var/lib/webhook/hooks && \
+    chown -R webhook:webhook /var/lib/webhook
 COPY --from=builder /app/webhook /usr/local/bin/webhook
 RUN chmod +x /usr/local/bin/webhook
 USER webhook
+WORKDIR /var/lib/webhook
 EXPOSE 9000/tcp
-CMD ["webhook"]
+ENTRYPOINT ["webhook"]

--- a/docker/manual/Dockerfile.alpine
+++ b/docker/manual/Dockerfile.alpine
@@ -1,9 +1,9 @@
-FROM golang:1.27.0-alpine3.23 AS builder
+FROM golang:1.27.0-alpine3.24 AS builder
 ARG VERSION=dev
 ARG COMMIT=unknown
 ARG BUILD_DATE=unknown
 ARG BRANCH=
-RUN apk --update add ca-certificates upx
+RUN apk add --no-cache ca-certificates upx
 ENV GOPROXY=https://goproxy.cn
 ENV CGO_ENABLED=0
 WORKDIR /app
@@ -20,15 +20,19 @@ RUN go build -ldflags "-w -s \
 RUN upx -9 -o webhook.minify webhook && \
     chmod +x webhook.minify
 
-FROM alpine:3.23
+FROM alpine:3.24.1
 LABEL maintainer "soulteary <soulteary@gmail.com>"
 # 安装 CA 证书
-RUN apk --no-cache add ca-certificates
+RUN apk add --no-cache ca-certificates
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 # 修复：从 builder stage 复制文件
 COPY --from=builder /app/webhook.minify /usr/bin/webhook
 # 创建非 root 用户
-RUN addgroup -S webhook && adduser -S -G webhook webhook
+RUN addgroup -S webhook && \
+    adduser -S -D -H -G webhook webhook && \
+    mkdir -p /var/lib/webhook/hooks && \
+    chown -R webhook:webhook /var/lib/webhook
 USER webhook
+WORKDIR /var/lib/webhook
 EXPOSE 9000/tcp
-CMD ["webhook"]
+ENTRYPOINT ["webhook"]

--- a/docs/en-US/API-Reference.md
+++ b/docs/en-US/API-Reference.md
@@ -217,6 +217,8 @@ The request body can contain:
   - Success: Custom message from `response-message`, command output (if `include-command-output-in-response` is enabled), or default message
   - Error: Plain-text compatibility message. Request and hook identifiers remain available in logs and tracing.
 
+Malformed, non-empty JSON sent with a JSON content type returns `400 Bad Request` with `Invalid JSON payload.`. Trigger rules and the configured command are not evaluated after this parsing failure. An empty body remains valid for hooks that authenticate the exact empty payload with HMAC.
+
 **Example - Successful Execution:**
 ```bash
 # POST request with JSON body

--- a/docs/en-US/Migration-Guide.md
+++ b/docs/en-US/Migration-Guide.md
@@ -38,9 +38,13 @@ This fork (soulteary/webhook) is based on the original webhook project (adnanh/w
    - Better logging and debugging
 
 4. **Configuration Compatibility:**
-   - Fully compatible with original hook configurations
+   - Compatibility with original hook definitions is a maintained target, not a blanket guarantee across major versions
    - Additional security and performance parameters
-   - Backward compatible with existing setups
+   - The default `compat` profile preserves historical runtime defaults; `secure` is an explicit, stricter opt-in
+
+### Compatibility Contract
+
+Hook JSON/YAML compatibility is tested and regressions are treated as bugs. Runtime behavior, HTTP error contracts, CLI options, defaults, and release asset names may still change in a major release. Review every intervening release note and validate in staging; do not infer upgrade safety only from hook-schema compatibility.
 
 ### Migration Steps
 
@@ -52,8 +56,10 @@ This fork (soulteary/webhook) is based on the original webhook project (adnanh/w
 
 2. **Download New Version:**
    ```bash
-   # Download from releases
-   wget https://github.com/soulteary/webhook/releases/latest/download/webhook-linux-amd64
+   # Download a versioned release archive
+   VERSION=7.1.0
+   wget "https://github.com/soulteary/webhook/releases/download/${VERSION}/webhook_${VERSION}_linux_amd64.tar.gz"
+   tar -xzf "webhook_${VERSION}_linux_amd64.tar.gz"
    
    # Or use Docker
    docker pull soulteary/webhook:latest
@@ -121,11 +127,12 @@ webhook -hooks hooks.json
 4. **Update:**
    ```bash
    # Download new version
-   wget https://github.com/soulteary/webhook/releases/download/vX.X.X/webhook-linux-amd64
+   VERSION=X.X.X
+   wget "https://github.com/soulteary/webhook/releases/download/${VERSION}/webhook_${VERSION}_linux_amd64.tar.gz"
+   tar -xzf "webhook_${VERSION}_linux_amd64.tar.gz"
    
    # Replace binary
-   sudo mv webhook-linux-amd64 /usr/local/bin/webhook
-   sudo chmod +x /usr/local/bin/webhook
+   sudo install -m 0755 webhook /usr/local/bin/webhook
    ```
 
 5. **Restart Service:**
@@ -202,9 +209,9 @@ webhook \
 
 ### Configuration File Format
 
-**Status:** No breaking changes in hook configuration format.
+**Status:** Hook-definition compatibility is a project target, but it is not a substitute for reviewing major-version changes.
 
-Hook configurations remain fully compatible. All existing configurations will work without modification.
+Existing adnanh/webhook definitions should normally validate without modification under the `compat` profile. Validate the exact configuration and exercise its trigger and error paths before upgrading production.
 
 ### Command-Line Arguments
 
@@ -231,7 +238,8 @@ All original endpoints work as before. New endpoints (`/health`, `/metrics`) are
    - Better error context
 
 3. **Security:**
-   - Stricter default behaviors (can be configured)
+   - `compat` preserves historical defaults
+   - `secure` enables POST-only handling, strict argument checks, rate limiting, request IDs, and audit logging, and requires a command allowlist
    - Enhanced validation
    - Better error handling
 
@@ -502,4 +510,3 @@ If you encounter issues during migration:
 - [Performance Tuning](Performance-Tuning.md) - Performance optimization
 - [Troubleshooting Guide](Troubleshooting.md) - Common issues and solutions
 - [API Reference](API-Reference.md) - API documentation
-

--- a/docs/en-US/Webhook-Parameters.md
+++ b/docs/en-US/Webhook-Parameters.md
@@ -8,6 +8,7 @@ This document describes all available command-line parameters and environment va
 
 | Flag | Description | Default |
 |------|-------------|---------|
+| `-profile string` | Configuration profile: `compat` preserves historical defaults; `secure` applies production-safe defaults and requires a command allowlist | `compat` |
 | `-ip string` | IP address the webhook should serve hooks on | `0.0.0.0` |
 | `-port int` | Port the webhook should serve hooks on | `9000` |
 | `-hooks value` | Explicit single-file mode: path to JSON/YAML hook definitions (can be used multiple times) | - |
@@ -170,6 +171,7 @@ All command-line parameters can also be set via environment variables:
 
 | Environment Variable | CLI Flag | Description | Default |
 |---------------------|----------|-------------|---------|
+| `PROFILE` | `-profile` | Configuration profile (`compat` or `secure`) | `compat` |
 | `HOST` | `-ip` | Listen IP address | `0.0.0.0` |
 | `PORT` | `-port` | Listen port | `9000` |
 | `HOOKS` | `-hooks` | Hook file paths (comma-separated, explicit single-file mode) | - |
@@ -299,6 +301,18 @@ All command-line parameters can also be set via environment variables:
 
 ## Security Best Practices
 
+### Secure Profile
+
+Use `-profile secure` for production-oriented defaults:
+
+```bash
+./webhook -profile secure \
+  -allowed-command-paths="/usr/bin,/opt/scripts" \
+  -hooks hooks.json
+```
+
+Unless explicitly overridden by a CLI flag or environment variable, this profile sets `-http-methods=POST`, `-strict-mode=true`, `-rate-limit-enabled=true`, `-x-request-id=true`, and `-audit-enabled=true`. Startup validation rejects the secure profile when `-allowed-command-paths` is empty. Hook authentication is still configured per hook; prefer an HMAC header rule.
+
 ### Command Path Whitelisting
 
 Use `-allowed-command-paths` to restrict which commands can be executed:
@@ -354,12 +368,10 @@ Alternatively, use `-hotreload` (or `HOT_RELOAD=true`) for automatic hot reloadi
 # Explicit single-file mode (still supported)
 ./webhook -hooks hooks.json -verbose
 
-# With security settings
-./webhook -hooks hooks.json \
-  -allowed-command-paths="/usr/bin,/opt/scripts" \
-  -strict-mode \
-  -rate-limit-enabled \
-  -rate-limit-rps=100
+# With production-oriented security defaults
+./webhook -profile secure \
+  -hooks hooks.json \
+  -allowed-command-paths="/usr/bin,/opt/scripts"
 
 # With HTTP server tuning
 ./webhook -hooks hooks.json \

--- a/docs/zh-CN/API-Reference.md
+++ b/docs/zh-CN/API-Reference.md
@@ -217,6 +217,8 @@ curl http://localhost:9000/openapi
   - 成功: 来自 `response-message` 的自定义消息、命令输出（如果启用了 `include-command-output-in-response`）或默认消息
   - 错误: 为兼容既有客户端返回纯文本消息；请求 ID 和 hook ID 仍可在日志及链路追踪中查询
 
+使用 JSON Content-Type 发送格式错误的非空 JSON 时，服务返回 `400 Bad Request` 和 `Invalid JSON payload.`，且不会继续计算触发规则或执行命令。为兼容对空 Payload 执行 HMAC 认证的 Hook，空请求体仍被接受。
+
 **示例 - 成功执行:**
 ```bash
 # 带 JSON 体的 POST 请求

--- a/docs/zh-CN/Migration-Guide.md
+++ b/docs/zh-CN/Migration-Guide.md
@@ -38,9 +38,13 @@
    - 更好的日志记录和调试
 
 4. **配置兼容性:**
-   - 与原始 hook 配置完全兼容
-   - 额外的安全和性能参数
-   - 与现有设置向后兼容
+   - 兼容原始 Hook 配置是持续维护目标，但不代表跨 Major Version 的无条件保证
+   - 提供额外的安全和性能参数
+   - 默认 `compat` Profile 保持历史运行时默认行为；`secure` 是显式启用的更严格模式
+
+### 兼容性契约
+
+项目会测试 Hook JSON/YAML 兼容性，并将回归视为缺陷。但 Major Version 仍可能调整运行时行为、HTTP 错误契约、CLI 参数、默认值和 Release 资产命名。升级时应阅读跨越版本的全部 Release Notes，并在预发布环境校验；不能仅凭 Hook Schema 兼容就判断升级无风险。
 
 ### 迁移步骤
 
@@ -52,8 +56,10 @@
 
 2. **下载新版本:**
    ```bash
-   # 从发布页面下载
-   wget https://github.com/soulteary/webhook/releases/latest/download/webhook-linux-amd64
+   # 下载带版本号的 Release 压缩包
+   VERSION=7.1.0
+   wget "https://github.com/soulteary/webhook/releases/download/${VERSION}/webhook_${VERSION}_linux_amd64.tar.gz"
+   tar -xzf "webhook_${VERSION}_linux_amd64.tar.gz"
    
    # 或使用 Docker
    docker pull soulteary/webhook:latest
@@ -121,11 +127,12 @@ webhook -hooks hooks.json
 4. **更新:**
    ```bash
    # 下载新版本
-   wget https://github.com/soulteary/webhook/releases/download/vX.X.X/webhook-linux-amd64
+   VERSION=X.X.X
+   wget "https://github.com/soulteary/webhook/releases/download/${VERSION}/webhook_${VERSION}_linux_amd64.tar.gz"
+   tar -xzf "webhook_${VERSION}_linux_amd64.tar.gz"
    
    # 替换二进制文件
-   sudo mv webhook-linux-amd64 /usr/local/bin/webhook
-   sudo chmod +x /usr/local/bin/webhook
+   sudo install -m 0755 webhook /usr/local/bin/webhook
    ```
 
 5. **重启服务:**
@@ -202,9 +209,9 @@ webhook \
 
 ### 配置文件格式
 
-**状态:** Hook 配置格式无破坏性更改。
+**状态:** Hook 配置兼容是项目目标，但不能代替对 Major Version 变化的审查。
 
-Hook 配置保持完全兼容。所有现有配置无需修改即可工作。
+现有 adnanh/webhook 配置在 `compat` Profile 下通常可以直接通过校验。升级生产环境前，仍应对准确配置执行校验，并测试触发、拒绝和错误路径。
 
 ### 命令行参数
 
@@ -231,7 +238,8 @@ Hook 配置保持完全兼容。所有现有配置无需修改即可工作。
    - 更好的错误上下文
 
 3. **安全性:**
-   - 更严格的默认行为（可配置）
+   - `compat` 保持历史默认行为
+   - `secure` 默认启用仅 POST、严格参数检查、限流、请求 ID 与审计日志，并要求命令白名单
    - 增强的验证
    - 更好的错误处理
 
@@ -502,4 +510,3 @@ docker run -d \
 - [性能调优](Performance-Tuning.md) - 性能优化
 - [故障排查指南](Troubleshooting.md) - 常见问题和解决方案
 - [API 参考](API-Reference.md) - API 文档
-

--- a/docs/zh-CN/Webhook-Parameters.md
+++ b/docs/zh-CN/Webhook-Parameters.md
@@ -12,6 +12,9 @@
 
 ### 基础配置
 
+- `-profile string`
+  配置 Profile：`compat` 保持历史默认行为；`secure` 应用生产安全默认值并要求配置命令白名单（默认值：`compat`）
+
 - `-ip string`
   指定 webhook 服务监听的 IP 地址（默认值：`0.0.0.0`）
 
@@ -177,6 +180,16 @@
 
 以下参数用于增强命令执行的安全性，防止命令注入攻击：
 
+生产环境建议使用 Secure Profile：
+
+```bash
+./webhook -profile secure \
+  -allowed-command-paths="/usr/bin,/opt/scripts" \
+  -hooks hooks.json
+```
+
+除非通过命令行参数或环境变量显式覆盖，该 Profile 会设置 `-http-methods=POST`、`-strict-mode=true`、`-rate-limit-enabled=true`、`-x-request-id=true` 和 `-audit-enabled=true`。如果命令白名单为空，启动校验会拒绝 Secure Profile。Hook 身份认证仍需在每个 Hook 中配置，推荐使用 HMAC 请求头规则。
+
 - `-allowed-command-paths string`
   指定允许执行的命令路径白名单（逗号分隔的目录或文件路径列表，默认值：空，表示不进行白名单检查）
   
@@ -298,6 +311,7 @@ Config UI 是**配置生成器**：用于在浏览器中生成单条 hook 的 YA
 
 | 环境变量 | 命令行参数 | 说明 | 默认值 |
 |---------|-----------|------|--------|
+| `PROFILE` | `-profile` | 配置 Profile（`compat` 或 `secure`） | `compat` |
 | `HOST` | `-ip` | 监听 IP 地址 | `0.0.0.0` |
 | `PORT` | `-port` | 监听端口 | `9000` |
 | `HOOKS` | `-hooks` | 钩子文件路径（多个用逗号分隔，显式启用单文件模式） | - |
@@ -454,6 +468,9 @@ export WRITE_TIMEOUT_SECONDS=60
 export ALLOWED_COMMAND_PATHS="/usr/bin,/opt/scripts"
 export MAX_ARG_LENGTH=1048576
 export STRICT_MODE=true
+
+# 或使用生产安全 Profile（命令白名单为必填项）
+export PROFILE=secure
 
 # 可选：启用 OpenAPI 规范（仅建议在调试或内网使用）
 # export OPENAPI_ENABLED=true

--- a/internal/flags/config.go
+++ b/internal/flags/config.go
@@ -20,6 +20,7 @@ func ParseConfig() AppFlags {
 	fs := flag.NewFlagSet("webhook", flag.ExitOnError)
 
 	// Define all flags
+	fs.String("profile", DEFAULT_PROFILE, "configuration profile: compat preserves historical defaults; secure enables production-safe defaults")
 	fs.String("ip", DEFAULT_HOST, "ip the webhook should serve hooks on")
 	fs.Int("port", DEFAULT_PORT, "port the webhook should serve hooks on")
 	fs.Bool("verbose", DEFAULT_ENABLE_VERBOSE, "show verbose output")
@@ -130,6 +131,7 @@ func ParseConfig() AppFlags {
 	var flags AppFlags
 
 	// Basic settings
+	flags.Profile = strings.ToLower(strings.TrimSpace(configutil.ResolveString(fs, "profile", ENV_KEY_PROFILE, DEFAULT_PROFILE, true)))
 	flags.Host = configutil.ResolveString(fs, "ip", ENV_KEY_HOST, DEFAULT_HOST, true)
 	flags.Port = configutil.ResolveInt(fs, "port", ENV_KEY_PORT, DEFAULT_PORT, false)
 	flags.Verbose = configutil.ResolveBool(fs, "verbose", ENV_KEY_VERBOSE, DEFAULT_ENABLE_VERBOSE)
@@ -210,6 +212,8 @@ func ParseConfig() AppFlags {
 	flags.ConfigUIEnabled = configutil.ResolveBool(fs, "config-ui", ENV_KEY_CONFIG_UI_ENABLED, DEFAULT_CONFIG_UI_ENABLED)
 	flags.ConfigUIPath = configutil.ResolveString(fs, "config-ui-path", ENV_KEY_CONFIG_UI_PATH, DEFAULT_CONFIG_UI_PATH, true)
 
+	applyProfileDefaults(&flags, visited)
+
 	// Hooks directory: when set, scan for hook files and optionally watch when empty
 	flags.HooksDir = configutil.ResolveString(fs, "hooks-dir", ENV_KEY_HOOKS_DIR, DEFAULT_HOOKS_DIR, true)
 	flags.HooksDir = strings.TrimSpace(flags.HooksDir)
@@ -276,4 +280,37 @@ func ParseConfig() AppFlags {
 	}
 
 	return flags
+}
+
+// applyProfileDefaults applies opinionated defaults without overriding explicit
+// CLI flags or environment variables. The compat profile intentionally leaves
+// historical behaviour unchanged.
+func applyProfileDefaults(appFlags *AppFlags, visited map[string]bool) {
+	if appFlags.Profile != "secure" {
+		return
+	}
+
+	if !configWasSet(visited, "http-methods", ENV_KEY_HTTP_METHODS) {
+		appFlags.HttpMethods = "POST"
+	}
+	if !configWasSet(visited, "strict-mode", ENV_KEY_STRICT_MODE) {
+		appFlags.StrictMode = true
+	}
+	if !configWasSet(visited, "rate-limit-enabled", ENV_KEY_RATE_LIMIT_ENABLED) {
+		appFlags.RateLimitEnabled = true
+	}
+	if !configWasSet(visited, "audit-enabled", ENV_KEY_AUDIT_ENABLED) {
+		appFlags.AuditEnabled = true
+	}
+	if !configWasSet(visited, "x-request-id", ENV_KEY_X_REQUEST_ID) {
+		appFlags.UseXRequestID = true
+	}
+}
+
+func configWasSet(visited map[string]bool, flagName, envName string) bool {
+	if visited[flagName] {
+		return true
+	}
+	value, ok := os.LookupEnv(envName)
+	return ok && strings.TrimSpace(value) != ""
 }

--- a/internal/flags/define.go
+++ b/internal/flags/define.go
@@ -10,6 +10,7 @@ const (
 	DEFAULT_URL_PREFIX   = "hooks"
 	DEFAULT_HTTP_METHODS = ""
 	DEFAULT_PID_FILE     = ""
+	DEFAULT_PROFILE      = "compat"
 
 	DEFAULT_ENABLE_VERBOSE        = false
 	DEFAULT_ENABLE_DEBUG          = false
@@ -90,8 +91,9 @@ const (
 )
 
 const (
-	ENV_KEY_HOST = "HOST"
-	ENV_KEY_PORT = "PORT"
+	ENV_KEY_HOST    = "HOST"
+	ENV_KEY_PORT    = "PORT"
+	ENV_KEY_PROFILE = "PROFILE"
 
 	ENV_KEY_VERBOSE    = "VERBOSE"
 	ENV_KEY_DEBUG      = "DEBUG"
@@ -176,6 +178,7 @@ const (
 )
 
 type AppFlags struct {
+	Profile            string
 	Host               string
 	Port               int
 	Verbose            bool

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -60,6 +60,71 @@ func TestParseConfig_DefaultValues(t *testing.T) {
 	assert.Equal(t, DEFAULT_I18N_DIR, flags.I18nDir)
 }
 
+func TestParseConfig_SecureProfileDefaults(t *testing.T) {
+	envKeys := []string{
+		ENV_KEY_PROFILE,
+		ENV_KEY_HTTP_METHODS,
+		ENV_KEY_STRICT_MODE,
+		ENV_KEY_RATE_LIMIT_ENABLED,
+		ENV_KEY_AUDIT_ENABLED,
+		ENV_KEY_X_REQUEST_ID,
+		ENV_KEY_ALLOWED_COMMAND_PATHS,
+		ENV_KEY_HOOKS,
+		ENV_KEY_HOOKS_DIR,
+	}
+	for _, key := range envKeys {
+		t.Setenv(key, "")
+	}
+
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+	os.Args = []string{"webhook", "-profile=secure", "-allowed-command-paths=/opt/scripts"}
+
+	appFlags := ParseConfig()
+	assert.Equal(t, "secure", appFlags.Profile)
+	assert.Equal(t, "POST", appFlags.HttpMethods)
+	assert.Equal(t, "/opt/scripts", appFlags.AllowedCommandPaths)
+	assert.True(t, appFlags.StrictMode)
+	assert.True(t, appFlags.RateLimitEnabled)
+	assert.True(t, appFlags.AuditEnabled)
+	assert.True(t, appFlags.UseXRequestID)
+}
+
+func TestParseConfig_SecureProfileRespectsExplicitOverrides(t *testing.T) {
+	envKeys := []string{
+		ENV_KEY_PROFILE,
+		ENV_KEY_HTTP_METHODS,
+		ENV_KEY_STRICT_MODE,
+		ENV_KEY_RATE_LIMIT_ENABLED,
+		ENV_KEY_AUDIT_ENABLED,
+		ENV_KEY_X_REQUEST_ID,
+		ENV_KEY_HOOKS,
+		ENV_KEY_HOOKS_DIR,
+	}
+	for _, key := range envKeys {
+		t.Setenv(key, "")
+	}
+
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+	os.Args = []string{
+		"webhook",
+		"-profile=secure",
+		"-http-methods=PATCH",
+		"-strict-mode=false",
+		"-rate-limit-enabled=false",
+		"-audit-enabled=false",
+		"-x-request-id=false",
+	}
+
+	appFlags := ParseConfig()
+	assert.Equal(t, "PATCH", appFlags.HttpMethods)
+	assert.False(t, appFlags.StrictMode)
+	assert.False(t, appFlags.RateLimitEnabled)
+	assert.False(t, appFlags.AuditEnabled)
+	assert.False(t, appFlags.UseXRequestID)
+}
+
 func TestParseConfig_FromEnvVars(t *testing.T) {
 	// Save original environment and args
 	originalEnv := make(map[string]string)

--- a/internal/flags/validate.go
+++ b/internal/flags/validate.go
@@ -46,7 +46,7 @@ func Validate(flags AppFlags) *ValidationResult {
 	default:
 		result.AddError("profile", "must be one of: compat, secure")
 	}
-	if flags.Profile == "secure" && strings.TrimSpace(flags.AllowedCommandPaths) == "" {
+	if flags.Profile == "secure" && !hasAllowedCommandPath(flags.AllowedCommandPaths) {
 		result.AddError("allowed-command-paths", "is required when profile is secure")
 	}
 
@@ -138,6 +138,15 @@ func Validate(flags AppFlags) *ValidationResult {
 	}
 
 	return result
+}
+
+func hasAllowedCommandPath(value string) bool {
+	for _, path := range strings.Split(value, ",") {
+		if strings.TrimSpace(path) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // validateFilePath 验证文件路径

--- a/internal/flags/validate.go
+++ b/internal/flags/validate.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/soulteary/cli-kit/validator"
 	"github.com/soulteary/webhook/internal/hook"
@@ -39,6 +40,15 @@ func (r *ValidationResult) HasErrors() bool {
 // Validate 验证配置的有效性
 func Validate(flags AppFlags) *ValidationResult {
 	result := &ValidationResult{}
+
+	switch flags.Profile {
+	case "", "compat", "secure":
+	default:
+		result.AddError("profile", "must be one of: compat, secure")
+	}
+	if flags.Profile == "secure" && strings.TrimSpace(flags.AllowedCommandPaths) == "" {
+		result.AddError("allowed-command-paths", "is required when profile is secure")
+	}
 
 	// 验证端口范围 - 使用 cli-kit/validator
 	if err := validator.ValidatePort(flags.Port); err != nil {

--- a/internal/flags/validate_test.go
+++ b/internal/flags/validate_test.go
@@ -32,6 +32,37 @@ func TestValidationResult(t *testing.T) {
 	assert.Len(t, result.Errors, 2)
 }
 
+func TestValidate_Profile(t *testing.T) {
+	tests := []struct {
+		name         string
+		profile      string
+		allowedPaths string
+		errorField   string
+	}{
+		{name: "compat profile", profile: "compat"},
+		{name: "secure profile with allowlist", profile: "secure", allowedPaths: "/opt/scripts"},
+		{name: "secure profile requires allowlist", profile: "secure", errorField: "allowed-command-paths"},
+		{name: "unknown profile", profile: "unknown", errorField: "profile"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			appFlags := createValidFlags()
+			appFlags.Profile = tt.profile
+			appFlags.AllowedCommandPaths = tt.allowedPaths
+
+			result := Validate(appFlags)
+			if tt.errorField == "" {
+				assert.False(t, result.HasErrors())
+				return
+			}
+
+			require.True(t, result.HasErrors())
+			assert.Contains(t, result.Errors[0].Error(), tt.errorField)
+		})
+	}
+}
+
 // createValidFlags 创建一个具有所有默认有效值的 AppFlags，用于测试
 func createValidFlags() AppFlags {
 	return AppFlags{

--- a/internal/flags/validate_test.go
+++ b/internal/flags/validate_test.go
@@ -42,6 +42,7 @@ func TestValidate_Profile(t *testing.T) {
 		{name: "compat profile", profile: "compat"},
 		{name: "secure profile with allowlist", profile: "secure", allowedPaths: "/opt/scripts"},
 		{name: "secure profile requires allowlist", profile: "secure", errorField: "allowed-command-paths"},
+		{name: "secure profile rejects separator-only allowlist", profile: "secure", allowedPaths: " , ,\t", errorField: "allowed-command-paths"},
 		{name: "unknown profile", profile: "unknown", errorField: "profile"},
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -552,12 +553,17 @@ func executeCapturingHook(w http.ResponseWriter, ctx context.Context, matchedHoo
 }
 
 // executeAsyncHook 执行异步 hook
-func executeAsyncHook(w http.ResponseWriter, ctx context.Context, matchedHook *hook.Hook, req *hook.Request, executor *HookExecutor, acquireTimeout time.Duration, requestID, hookID string, startTime time.Time) {
+func executeAsyncHook(w http.ResponseWriter, _ context.Context, matchedHook *hook.Hook, req *hook.Request, executor *HookExecutor, acquireTimeout time.Duration, requestID, hookID string, startTime time.Time) {
+	// Fiber/fasthttp reuses its request buffers as soon as the handler returns.
+	// Detach every value consumed by the background command before starting it.
+	asyncRequest := cloneRequestForAsync(req)
+	asyncContext := context.Background()
+
 	// 获取请求信息用于审计日志（在 goroutine 外获取，避免请求对象被回收）
 	var ip, userAgent string
-	if req.RawRequest != nil {
-		ip = req.RawRequest.RemoteAddr
-		userAgent = req.RawRequest.UserAgent()
+	if asyncRequest.RawRequest != nil {
+		ip = asyncRequest.RawRequest.RemoteAddr
+		userAgent = asyncRequest.RawRequest.UserAgent()
 	}
 
 	// 异步执行，但仍需要并发控制和超时
@@ -565,7 +571,7 @@ func executeAsyncHook(w http.ResponseWriter, ctx context.Context, matchedHook *h
 	asyncHookWaitGroup.Add(1)
 	go func() {
 		defer asyncHookWaitGroup.Done()
-		_, err := executor.Execute(ctx, matchedHook, req, nil, acquireTimeout)
+		_, err := executor.Execute(asyncContext, matchedHook, asyncRequest, nil, acquireTimeout)
 		duration := time.Since(startTime)
 		durationMS := duration.Milliseconds()
 
@@ -602,6 +608,75 @@ func executeAsyncHook(w http.ResponseWriter, ctx context.Context, matchedHook *h
 	}
 
 	_, _ = fmt.Fprint(w, matchedHook.ResponseMessage)
+}
+
+func cloneRequestForAsync(req *hook.Request) *hook.Request {
+	if req == nil {
+		return nil
+	}
+
+	cloned := &hook.Request{
+		ID:                   strings.Clone(req.ID),
+		ContentType:          strings.Clone(req.ContentType),
+		Body:                 bytes.Clone(req.Body),
+		Headers:              cloneRequestValues(req.Headers),
+		Query:                cloneRequestValues(req.Query),
+		Payload:              cloneRequestValues(req.Payload),
+		AllowSignatureErrors: req.AllowSignatureErrors,
+	}
+	if req.RawRequest != nil {
+		cloned.RawRequest = &http.Request{
+			Method:     strings.Clone(req.RawRequest.Method),
+			RemoteAddr: strings.Clone(req.RawRequest.RemoteAddr),
+			Header:     make(http.Header, len(req.RawRequest.Header)),
+		}
+		for key, values := range req.RawRequest.Header {
+			clonedValues := make([]string, len(values))
+			for i, value := range values {
+				clonedValues[i] = strings.Clone(value)
+			}
+			cloned.RawRequest.Header[strings.Clone(key)] = clonedValues
+		}
+	}
+
+	return cloned
+}
+
+func cloneRequestValues(values map[string]interface{}) map[string]interface{} {
+	if values == nil {
+		return nil
+	}
+
+	cloned := make(map[string]interface{}, len(values))
+	for key, value := range values {
+		cloned[strings.Clone(key)] = cloneRequestValue(value)
+	}
+	return cloned
+}
+
+func cloneRequestValue(value interface{}) interface{} {
+	switch value := value.(type) {
+	case string:
+		return strings.Clone(value)
+	case []byte:
+		return bytes.Clone(value)
+	case []string:
+		cloned := make([]string, len(value))
+		for i, item := range value {
+			cloned[i] = strings.Clone(item)
+		}
+		return cloned
+	case []interface{}:
+		cloned := make([]interface{}, len(value))
+		for i, item := range value {
+			cloned[i] = cloneRequestValue(item)
+		}
+		return cloned
+	case map[string]interface{}:
+		return cloneRequestValues(value)
+	default:
+		return value
+	}
 }
 
 func resolveHookTimeouts(appFlags flags.AppFlags) (commandTimeout, acquireTimeout time.Duration) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -210,6 +210,14 @@ func parseRequestBody(w http.ResponseWriter, r *http.Request, req *hook.Request,
 		err := req.ParseJSONPayload()
 		if err != nil {
 			logger.Warnf("[%s] %s", requestID, err)
+			// Preserve the historical empty-body HMAC use case. A non-empty body
+			// that claims to be JSON must be valid and is rejected before trigger
+			// evaluation or command execution.
+			if len(req.Body) != 0 {
+				HandleErrorPlain(w, NewHTTPError(ErrorTypeClient, http.StatusBadRequest,
+					"Invalid JSON payload.", err), requestID, hookID)
+				return err
+			}
 		}
 
 	case strings.Contains(req.ContentType, "x-www-form-urlencoded"):

--- a/internal/server/web.go
+++ b/internal/server/web.go
@@ -168,9 +168,13 @@ func Launch(appFlags flags.AppFlags, addr string, ln net.Listener) *Server {
 	healthHandler := func(w http.ResponseWriter, r *http.Request) {
 		startTime := time.Now()
 		handler := healthkit.Handler(healthAggregator)
-		handler(w, r)
+		// The fasthttp adapter's request context is backed by server-owned state.
+		// Health checks may derive child contexts, so detach them before shutdown
+		// can recycle or mutate that state.
+		detachedRequest := r.Clone(context.Background())
+		handler(w, detachedRequest)
 		duration := time.Since(startTime)
-		result := healthAggregator.Check(r.Context())
+		result := healthAggregator.Check(context.Background())
 		statusCode := healthkit.HTTPStatusCode(result.Status)
 		metrics.RecordHTTPRequest(r.Method, fmt.Sprintf("%d", statusCode), "/health", duration)
 	}
@@ -187,9 +191,10 @@ func Launch(appFlags flags.AppFlags, addr string, ln net.Listener) *Server {
 	readyzHandler := func(w http.ResponseWriter, r *http.Request) {
 		startTime := time.Now()
 		handler := healthkit.ReadinessHandler(healthAggregator)
-		handler(w, r)
+		detachedRequest := r.Clone(context.Background())
+		handler(w, detachedRequest)
 		duration := time.Since(startTime)
-		result := healthAggregator.Check(r.Context())
+		result := healthAggregator.Check(context.Background())
 		statusCode := healthkit.HTTPStatusCode(result.Status)
 		metrics.RecordHTTPRequest(r.Method, fmt.Sprintf("%d", statusCode), "/readyz", duration)
 	}

--- a/internal/server/webhook_test.go
+++ b/internal/server/webhook_test.go
@@ -191,6 +191,31 @@ func TestCreateHookHandler_HookNotFound(t *testing.T) {
 	assert.Contains(t, string(body), "Hook not found")
 }
 
+func TestCreateHookHandler_RejectsMalformedJSON(t *testing.T) {
+	testHook := hook.Hook{
+		ID:              "test-hook",
+		ResponseMessage: "must not execute",
+	}
+	rules.LoadedHooksFromFiles = map[string]hook.Hooks{
+		"test.json": {testHook},
+	}
+	rules.BuildIndex()
+
+	handler := createHookHandler(flags.AppFlags{}, nil)
+	req := httptest.NewRequest("POST", "/hooks/test-hook", bytes.NewBufferString(`{"broken":`))
+	req.Header.Set("Content-Type", "application/json")
+
+	app := testHookApp(handler)
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: 5 * time.Second})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "Invalid JSON payload.", string(body))
+}
+
 func TestCreateHookHandler_MethodNotAllowed(t *testing.T) {
 	// Setup
 	testHook := hook.Hook{

--- a/release_metadata_test.go
+++ b/release_metadata_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -34,5 +35,33 @@ func TestGoReleaserInjectsCompleteVersionMetadata(t *testing.T) {
 		for _, value := range required {
 			assert.Contains(t, joined, value, "build %q must inject complete version metadata", build.ID)
 		}
+	}
+}
+
+func TestGoReleaserPublishesSupplyChainMetadata(t *testing.T) {
+	data, err := os.ReadFile(".goreleaser.yaml")
+	require.NoError(t, err)
+
+	contents := string(data)
+	assert.Contains(t, contents, "sboms:")
+	assert.Contains(t, contents, "artifacts: archive")
+	assert.Contains(t, contents, "signs:")
+	assert.Contains(t, contents, "--bundle=${signature}")
+	assert.Contains(t, contents, "docker_signs:")
+	assert.Contains(t, contents, "${artifact}@${digest}")
+}
+
+func TestReleaseDockerfilesRunAsNonRoot(t *testing.T) {
+	for _, path := range []string{
+		"docker/goreleaser/Dockerfile",
+		"docker/goreleaser/Dockerfile.extend",
+	} {
+		t.Run(path, func(t *testing.T) {
+			data, err := os.ReadFile(path)
+			require.NoError(t, err)
+			contents := string(data)
+			assert.Regexp(t, regexp.MustCompile(`(?m)^USER\s+[^\s]+`), contents)
+			assert.NotContains(t, contents, "alpine:3.19")
+		})
 	}
 }


### PR DESCRIPTION
## Summary

This PR closes the P0 trust, security-baseline, and release-contract gaps identified in the project review.

- introduce an opt-in `secure` profile while preserving the historical `compat` defaults
- reject malformed non-empty JSON with HTTP 400 before trigger evaluation or command execution
- clarify positioning, upstream configuration compatibility, product boundaries, release assets, and HMAC-first production guidance
- make all published Docker variants non-root and document the core/extended runtime split
- pin GitHub Actions and release tools, apply least-privilege scan permissions, fail security scans closed, and add `govulncheck` plus race testing
- publish archive SBOMs, keyless checksum signatures, container signatures, and GitHub build-provenance attestations
- add a reproducible benchmark workflow with environment metadata and five samples

## Compatibility

The default profile remains `compat`, so existing installations retain their current defaults. The `secure` profile is explicit and requires at least one effective entry in `-allowed-command-paths`.

Empty JSON request bodies remain accepted for existing empty-payload HMAC hooks. Only malformed, non-empty JSON now returns `400 Invalid JSON payload.`.

## CI findings fixed in this PR

- pin `govulncheck` to a Go 1.27-compatible upstream revision after v1.1.4 panicked during SSA construction
- detach asynchronous hook execution from Fiber/fasthttp request buffers and request cancellation
- detach health-check child contexts from fasthttp server-owned state
- reject separator-only secure command allowlists such as `-allowed-command-paths=,`

## Validation

Passed locally:

- `go build ./...`
- `go vet ./...`
- targeted unit tests for profiles, validation, JSON handling, CI policy, and release metadata
- repeated race-enabled tests for asynchronous requests and shutdown
- workflow and GoReleaser YAML parsing
- `goreleaser check` with v2.18.0
- `govulncheck` with the pinned Go 1.27-compatible revision
- `git diff --check`

All required GitHub Actions are green on `d7361de`: Tests (full `-race` suite), Security Scan, CodeQL, and Benchmarks.