### PR TITLE
ci: fix Cosign v3 installation in release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
           syft-version: v1.51.1
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
           cosign-release: v3.1.3
 


### PR DESCRIPTION
## Summary

- upgrade `sigstore/cosign-installer` from v3.9.1 to v4.1.2
- keep the action pinned to the full commit SHA
- continue installing Cosign v3.1.3

## Problem

The 7.2.0 release job failed during `Install Cosign` because the old installer requested `cosign-linux-amd64.sig`. Cosign v3.1.3 publishes the verification material as `cosign-linux-amd64.sigstore.json`, so the download returned HTTP 404 (`curl` exit code 22).

Failed job: https://github.com/soulteary/webhook/actions/runs/34029044817/job/101475109733

## Why this fixes it

`cosign-installer` v4 supports the Sigstore bundle assets published by Cosign 3.x and verifies the requested binary using the `.sigstore.json` bundle.