### PR TITLE
build: remove duplicate Config UI release binary

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,24 +24,6 @@ builds:
       - "7"
       - "6"
 
-  # Config UI binary (same code as main binary; run with -config-ui to enable UI on webhook server)
-  - <<: *build_defaults
-    id: config-ui-macos
-    main: .
-    binary: webhook-config-ui
-    goos: [darwin]
-    goarch: [amd64, arm64]
-
-  - <<: *build_defaults
-    id: config-ui-linux
-    main: .
-    binary: webhook-config-ui
-    goos: [linux]
-    goarch: ["386", arm, amd64, arm64]
-    goarm:
-      - "7"
-      - "6"
-
 dockers:
   - image_templates:
       - "soulteary/webhook:linux-amd64-{{ .Tag }}"

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -34,7 +34,7 @@ go build -o webhook .
 ./webhook -config-ui -port 9090
 ```
 
-发布产物中的 `webhook-config-ui` 与 `webhook` 为同一程序，用法一致。运行 `./webhook -config-ui` 或 `./webhook-config-ui -config-ui` 即可，默认监听 9000。
+发布产物只包含 `webhook`。运行 `./webhook -config-ui` 即可启用 Config UI，默认监听 9000；无需下载或维护第二份完全相同的二进制。
 
 ## 使用说明
 

--- a/release_metadata_test.go
+++ b/release_metadata_test.go
@@ -38,6 +38,25 @@ func TestGoReleaserInjectsCompleteVersionMetadata(t *testing.T) {
 	}
 }
 
+func TestGoReleaserDoesNotPublishDuplicateConfigUIBinary(t *testing.T) {
+	data, err := os.ReadFile(".goreleaser.yaml")
+	require.NoError(t, err)
+
+	var config struct {
+		Builds []struct {
+			ID     string `json:"id"`
+			Binary string `json:"binary"`
+		} `json:"builds"`
+	}
+	require.NoError(t, yaml.Unmarshal(data, &config))
+	require.NotEmpty(t, config.Builds)
+
+	for _, build := range config.Builds {
+		assert.NotEqual(t, "webhook-config-ui", build.Binary,
+			"build %q duplicates the main webhook binary; enable Config UI with -config-ui", build.ID)
+	}
+}
+
 func TestGoReleaserPublishesSupplyChainMetadata(t *testing.T) {
 	data, err := os.ReadFile(".goreleaser.yaml")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- remove the `config-ui-macos` and `config-ui-linux` GoReleaser builds
- keep Config UI available from the main `webhook` binary through `-config-ui`
- update the Config UI documentation to describe the single-binary release contract
- add a regression test that prevents `webhook-config-ui` from returning as a duplicate build

The 7.2.0 archives publish `webhook` and `webhook-config-ui` with identical SHA-256 hashes. This change keeps one copy per target without removing any Config UI functionality.

## Testing

- `go test .`
- `git diff --check`
