### PR TITLE
docs: prepare the 7.3.0 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,13 @@
 name: Release
 
 on:
-  workflow_dispatch:
   push:
     tags:
       - "*.*.*"
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   GO111MODULE: on
@@ -14,19 +17,27 @@ permissions:
   contents: read
 
 jobs:
-  release:
-    if: github.ref_type == 'tag'
+  publish:
+    if: github.event_name == 'push' && github.ref_type == 'tag'
     runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write
       id-token: write
-      attestations: write
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
+
+      - name: Validate release ref
+        run: |
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "release tag must be a stable semantic version such as 7.3.0" >&2
+            exit 1
+          fi
+          git fetch origin main
+          git merge-base --is-ancestor "${GITHUB_SHA}" origin/main
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
@@ -81,6 +92,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  attest:
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    steps:
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir dist
+          gh release download "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" --dir dist
+
       - name: Attest release artifacts
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
         with:
@@ -88,6 +115,26 @@ jobs:
             dist/*.tar.gz
             dist/*_checksums.txt
             dist/*.sbom.json
+
+  verify:
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    needs: attest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      attestations: read
+    steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.1.3
+
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir dist
+          gh release download "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" --dir dist
 
       - name: Verify release assets and signatures
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           mkdir -p "${RUNNER_TEMP}/webhook-container"
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-            -ldflags '-w -s -X github.com/soulteary/webhook/internal/version.Version=7.2.0-test' \
+            -ldflags '-w -s -X github.com/soulteary/webhook/internal/version.Version=ci-test' \
             -o "${RUNNER_TEMP}/webhook-container/webhook" .
 
       - name: Build all runtime variants
@@ -70,7 +70,7 @@ jobs:
         run: |
           for variant in core runner extended; do
             test "$(docker image inspect --format '{{ .Config.User }}' "webhook:${variant}-test")" = "65532:65532"
-            docker run --rm "webhook:${variant}-test" -version | grep '7.2.0-test'
+            docker run --rm "webhook:${variant}-test" -version | grep 'ci-test'
           done
 
           if docker run --rm --entrypoint /bin/sh webhook:core-test -c true; then

--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ Download pre-built binaries for Linux and macOS from the [Releases page](https:/
 # Latest stable core image
 docker pull soulteary/webhook:latest
 
-# Minimal scratch image (the unprefixed 7.2.0 tag is an alias)
-docker pull soulteary/webhook:core-7.2.0
+# Minimal scratch image (the unprefixed 7.3.0 tag is an alias)
+docker pull soulteary/webhook:core-7.3.0
 
 # Shell-script runtime
-docker pull soulteary/webhook:runner-7.2.0
+docker pull soulteary/webhook:runner-7.3.0
 
 # Runtime with debugging and network tools
-docker pull soulteary/webhook:extended-7.2.0
+docker pull soulteary/webhook:extended-7.3.0
 ```
 
 | Variant | Contents | Intended use |
@@ -91,7 +91,7 @@ docker pull soulteary/webhook:extended-7.2.0
 | `runner` | Alpine, BusyBox utilities, Bash, and CA certificates | Normal shell-script hooks without bundled debugging clients |
 | `extended` | `runner` plus curl, jq, and yq | Troubleshooting and scripts that explicitly need these tools |
 
-All release variants run as UID/GID `65532` from `/var/lib/webhook`. The unprefixed `<version>` and `latest` tags point to `core`. The historical `extend-<version>` name remains a compatibility alias for `extended-<version>` in 7.2.0, but new deployments should use `extended-*`.
+All release variants run as UID/GID `65532` from `/var/lib/webhook`. The unprefixed `<version>` and `latest` tags point to `core`. The historical `extend-<version>` name remains a compatibility alias for `extended-<version>` since 7.2.0, but new deployments should use `extended-*`.
 
 Prefer `core` or `runner` in production. `extended` has a deliberately larger package set and attack surface; do not select it only for interactive convenience. Ensure mounted hooks, commands, and audit paths are readable or writable by UID/GID `65532`. See [Container images](docs/en-US/Container-Images.md) for the complete tag and migration contract.
 
@@ -234,6 +234,7 @@ For more examples and use cases, check out [Hook Examples](docs/en-US/Hook-Examp
 - [Testing Guide](docs/en-US/Testing-Guide.md) - How to run tests, generate coverage reports, and key testing scenarios
 - [Troubleshooting](docs/en-US/Troubleshooting.md) - Common issues and solutions
 - [Migration Guide](docs/en-US/Migration-Guide.md) - Upgrading from previous versions
+- [Release Guide](docs/en-US/Release-Guide.md) - Maintainer sequence for publishing a version safely
 
 ### Security
 - [Security Policy](SECURITY.md) - Security features and vulnerability reporting
@@ -243,18 +244,18 @@ For more examples and use cases, check out [Hook Examples](docs/en-US/Hook-Examp
 Tagged releases publish SPDX SBOMs, a keyless Sigstore bundle for the checksum file, signed multi-architecture container manifests, and GitHub build-provenance attestations. Examples:
 
 ```bash
-gh attestation verify webhook_7.2.0_linux_amd64.tar.gz -R soulteary/webhook
+gh attestation verify webhook_7.3.0_linux_amd64.tar.gz -R soulteary/webhook
 
 cosign verify-blob \
-  --bundle webhook_7.2.0_checksums.txt.sigstore.json \
+  --bundle webhook_7.3.0_checksums.txt.sigstore.json \
   --certificate-identity-regexp='^https://github.com/soulteary/webhook/.github/workflows/build.yml@refs/tags/.+$' \
   --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
-  webhook_7.2.0_checksums.txt
+  webhook_7.3.0_checksums.txt
 
 cosign verify \
-  --certificate-identity='https://github.com/soulteary/webhook/.github/workflows/build.yml@refs/tags/7.2.0' \
+  --certificate-identity='https://github.com/soulteary/webhook/.github/workflows/build.yml@refs/tags/7.3.0' \
   --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
-  ghcr.io/soulteary/webhook:runner-7.2.0
+  ghcr.io/soulteary/webhook:runner-7.3.0
 ```
 
 ## About This Fork

--- a/docs/en-US/Container-Images.md
+++ b/docs/en-US/Container-Images.md
@@ -1,16 +1,16 @@
 # Container images
 
-WebHook 7.2.0 publishes three multi-architecture runtime variants to Docker Hub
+WebHook 7.3.0 publishes three multi-architecture runtime variants to Docker Hub
 and GHCR. All variants run as UID/GID `65532`, use `/var/lib/webhook` as their
 working directory, and contain the same statically linked WebHook binary.
 
 | Variant | Versioned tag | Runtime contents | Use it when |
 |---|---|---|---|
-| Core | `core-7.2.0` | `scratch`, CA certificates, WebHook | Every executed command is a mounted static binary |
-| Runner | `runner-7.2.0` | Alpine, BusyBox utilities, Bash, CA certificates | Hooks execute ordinary POSIX shell or Bash scripts |
-| Extended | `extended-7.2.0` | Runner plus curl, jq, and yq | Hooks explicitly require network or JSON/YAML command-line tools |
+| Core | `core-7.3.0` | `scratch`, CA certificates, WebHook | Every executed command is a mounted static binary |
+| Runner | `runner-7.3.0` | Alpine, BusyBox utilities, Bash, CA certificates | Hooks execute ordinary POSIX shell or Bash scripts |
+| Extended | `extended-7.3.0` | Runner plus curl, jq, and yq | Hooks explicitly require network or JSON/YAML command-line tools |
 
-The unprefixed `7.2.0` and `latest` tags are aliases for `core-7.2.0`. Pin a
+The unprefixed `7.3.0` and `latest` tags are aliases for `core-7.3.0`. Pin a
 versioned tag, or preferably an image digest, in production. Both registries use
 the same tag contract:
 
@@ -40,16 +40,16 @@ secure profile's command allowlist. Mounted files must be accessible to UID/GID
 
 ## Migrating from 7.1
 
-The old `extend-7.2.0` tag remains as a compatibility alias for
-`extended-7.2.0`. Existing deployments can move without an immediate rename,
+The old `extend-7.3.0` tag remains as a compatibility alias for
+`extended-7.3.0`. Existing deployments can move without an immediate rename,
 but new configuration should use `extended-*`.
 
 The old extended image was commonly used for every script hook. In 7.2, choose
 the smallest matching runtime:
 
-- Move shell-only hooks to `runner-7.2.0`.
-- Keep hooks that require curl, jq, or yq on `extended-7.2.0`.
-- Use `core-7.2.0` only when the configured command is a static executable.
+- Move shell-only hooks to `runner-7.3.0`.
+- Keep hooks that require curl, jq, or yq on `extended-7.3.0`.
+- Use `core-7.3.0` only when the configured command is a static executable.
 
 The default image remains shell-free, so changing an existing script-based
 deployment from `extend-*` to the unprefixed version tag will not work.

--- a/docs/en-US/Migration-Guide.md
+++ b/docs/en-US/Migration-Guide.md
@@ -57,7 +57,7 @@ Hook JSON/YAML compatibility is tested and regressions are treated as bugs. Runt
 2. **Download New Version:**
    ```bash
    # Download a versioned release archive
-   VERSION=7.2.0
+   VERSION=7.3.0
    wget "https://github.com/soulteary/webhook/releases/download/${VERSION}/webhook_${VERSION}_linux_amd64.tar.gz"
    tar -xzf "webhook_${VERSION}_linux_amd64.tar.gz"
    

--- a/docs/en-US/Release-Guide.md
+++ b/docs/en-US/Release-Guide.md
@@ -1,0 +1,131 @@
+# Release guide
+
+This is the maintainer runbook for publishing a stable WebHook release. A
+release is created only by pushing one immutable semantic-version tag. Do not
+create a GitHub Release manually and do not run the Release workflow from the
+Actions page.
+
+## 7.3.0 scope
+
+The 7.3.0 release includes the following changes after 7.2.0:
+
+- remove the duplicate `webhook-config-ui` release binary; use
+  `webhook -config-ui` with the single published binary;
+- add constrained Docker Secret template support through `getSecret` and
+  `trimSpace`, without exposing arbitrary filesystem reads;
+- update examples, container tags, integrity commands, and migration downloads
+  to 7.3.0;
+- make Release CI tag-only and split publishing, attestation, and verification
+  into retry-safe jobs.
+
+## Release invariants
+
+- The release tag is exactly `MAJOR.MINOR.PATCH`, without a `v` prefix.
+- The tagged commit is already on `main`, and all required checks passed on it.
+- A version is tagged once. Never move, delete, or reuse a published tag.
+- The Release workflow creates the GitHub Release and both registries' images.
+- `publish` runs once. `attest`, `verify`, or Documentation may be retried
+  independently without running GoReleaser again.
+
+## Prerequisites
+
+Before preparing a tag:
+
+1. Merge every release PR, including the version/documentation preparation PR.
+2. Wait for Tests, container smoke tests, Security Scan, CodeQL, Documentation,
+   and Benchmarks on the resulting `main` commit.
+3. Confirm the Docker Hub credentials and GitHub repository/package permissions
+   are available to Actions.
+4. Install Go according to `go.mod`, MkDocs dependencies from
+   `requirements-docs.txt`, GitHub CLI, and GoReleaser v2.18.0 locally.
+
+For 7.3.0, PR #177 and PR #178 must both be present in the selected `main`
+commit.
+
+## Exact publishing sequence
+
+Run these commands from a clean clone. `release-preflight.sh` refuses to run
+from a branch other than `main`, from a dirty or stale checkout, or when the tag
+already exists.
+
+```bash
+git fetch origin main --tags
+git switch main
+git pull --ff-only origin main
+
+RELEASE_VERSION=7.3.0
+./scripts/release-preflight.sh "$RELEASE_VERSION"
+
+RELEASE_COMMIT="$(git rev-parse HEAD)"
+git tag -a "$RELEASE_VERSION" "$RELEASE_COMMIT" -m "Release $RELEASE_VERSION"
+git push origin "refs/tags/$RELEASE_VERSION"
+```
+
+Push only the one tag shown above. Do not use `git push --tags`; it can publish
+an unrelated local tag. Do not create a draft or empty GitHub Release before
+the push, because GoReleaser owns that operation.
+
+The tag push starts these paths:
+
+| Order | Workflow/job | Side effects | Retry rule |
+|---|---|---|---|
+| 1 | Release / `publish` | Tests, builds, GitHub Release, archives, SBOMs, signed container manifests | Run once only |
+| 2 | Release / `attest` | Downloads published assets and creates GitHub provenance | Retry this job only |
+| 3 | Release / `verify` | Verifies assets, Sigstore bundle, provenance, image UID, and image signatures | Retry this job only |
+| Parallel | Documentation | Builds `7.3.0`, updates `latest`, and sets the documentation default | Retry independently |
+
+Wait for both workflows; a visible GitHub Release is not completion by itself.
+
+```bash
+RELEASE_RUN_ID="$(gh run list --workflow build.yml --branch "$RELEASE_VERSION" --limit 1 --json databaseId --jq '.[0].databaseId')"
+gh run watch "$RELEASE_RUN_ID" --exit-status
+
+DOCS_RUN_ID="$(gh run list --workflow docs.yml --branch "$RELEASE_VERSION" --limit 1 --json databaseId --jq '.[0].databaseId')"
+gh run watch "$DOCS_RUN_ID" --exit-status
+```
+
+## Post-release verification
+
+After both workflows pass:
+
+```bash
+gh release view "$RELEASE_VERSION" --repo soulteary/webhook \
+  --json tagName,isDraft,isPrerelease,url
+
+mkdir -p "release-$RELEASE_VERSION"
+gh release download "$RELEASE_VERSION" --repo soulteary/webhook \
+  --dir "release-$RELEASE_VERSION"
+find "release-$RELEASE_VERSION" -maxdepth 1 -type f -printf '%f\n' | sort
+
+test -z "$(find "release-$RELEASE_VERSION" -name '*webhook-config-ui*' -print -quit)"
+
+for variant in core runner extended; do
+  image="ghcr.io/soulteary/webhook:${variant}-${RELEASE_VERSION}"
+  docker pull "$image"
+  test "$(docker image inspect --format '{{ .Config.User }}' "$image")" = "65532:65532"
+  docker run --rm "$image" -version | grep "$RELEASE_VERSION"
+done
+```
+
+Also confirm that both
+`https://soulteary.github.io/webhook/7.3.0/` and the `latest` documentation URL
+resolve correctly. The Release workflow already verifies the checksum Sigstore
+bundle, GitHub attestation, image signatures, and all three runtime variants.
+
+## Failure handling
+
+Do not immediately press **Re-run all jobs**.
+
+| Failure point | Safe action |
+|---|---|
+| Preparation PR or local preflight | Fix the branch and rerun checks; no release exists yet |
+| `publish`, before **Run GoReleaser** starts | Re-run the failed `publish` job |
+| `publish`, after **Run GoReleaser** starts | Do not rerun; inspect the GitHub Release and both registries for partial immutable artifacts |
+| `attest` | Re-run failed jobs; `publish` remains completed |
+| `verify` | Re-run failed jobs or the `verify` job only |
+| Documentation | Re-run only the Documentation workflow |
+
+If GoReleaser started and any versioned release asset or image exists, do not
+delete the tag and reuse the version. Preserve the evidence, fix the cause on
+`main`, and publish the next patch version (for example, 7.3.1). This avoids
+serving different bytes under the same immutable version.

--- a/docs/zh-CN/Container-Images.md
+++ b/docs/zh-CN/Container-Images.md
@@ -1,16 +1,16 @@
 # 容器镜像
 
-WebHook 7.2.0 会向 Docker Hub 和 GHCR 发布三种多架构运行时镜像。所有变体
+WebHook 7.3.0 会向 Docker Hub 和 GHCR 发布三种多架构运行时镜像。所有变体
 都以 UID/GID `65532` 运行，工作目录均为 `/var/lib/webhook`，并包含同一个
 静态链接的 WebHook 可执行文件。
 
 | 变体 | 版本标签 | 运行时内容 | 适用场景 |
 |---|---|---|---|
-| Core | `core-7.2.0` | `scratch`、CA 证书、WebHook | 所有被执行命令都是挂载进来的静态可执行文件 |
-| Runner | `runner-7.2.0` | Alpine、BusyBox 工具、Bash、CA 证书 | Hook 执行普通 POSIX Shell 或 Bash 脚本 |
-| Extended | `extended-7.2.0` | Runner 加 curl、jq 和 yq | Hook 明确依赖网络或 JSON/YAML 命令行工具 |
+| Core | `core-7.3.0` | `scratch`、CA 证书、WebHook | 所有被执行命令都是挂载进来的静态可执行文件 |
+| Runner | `runner-7.3.0` | Alpine、BusyBox 工具、Bash、CA 证书 | Hook 执行普通 POSIX Shell 或 Bash 脚本 |
+| Extended | `extended-7.3.0` | Runner 加 curl、jq 和 yq | Hook 明确依赖网络或 JSON/YAML 命令行工具 |
 
-无前缀的 `7.2.0` 和 `latest` 都是 `core-7.2.0` 的别名。生产环境应固定
+无前缀的 `7.3.0` 和 `latest` 都是 `core-7.3.0` 的别名。生产环境应固定
 版本标签，最好进一步固定镜像 Digest。两个镜像仓库使用相同的标签规则：
 
 ```text
@@ -36,14 +36,14 @@ UID/GID `65532` 访问。
 
 ## 从 7.1 迁移
 
-旧名称 `extend-7.2.0` 会继续作为 `extended-7.2.0` 的兼容别名。现有部署
+旧名称 `extend-7.3.0` 会继续作为 `extended-7.3.0` 的兼容别名。现有部署
 不必立即改名，但新配置应使用 `extended-*`。
 
 旧版 Extended 镜像经常承担所有脚本执行场景。7.2 应按实际依赖选择最小运行时：
 
-- 只有 Shell 依赖的 Hook 迁移到 `runner-7.2.0`。
-- 需要 curl、jq 或 yq 的 Hook 使用 `extended-7.2.0`。
-- 只有命令本身为静态可执行文件时才使用 `core-7.2.0`。
+- 只有 Shell 依赖的 Hook 迁移到 `runner-7.3.0`。
+- 需要 curl、jq 或 yq 的 Hook 使用 `extended-7.3.0`。
+- 只有命令本身为静态可执行文件时才使用 `core-7.3.0`。
 
 默认镜像仍不包含 Shell，因此不能把现有的脚本型部署从 `extend-*` 直接改成无
 前缀的版本标签。

--- a/docs/zh-CN/Migration-Guide.md
+++ b/docs/zh-CN/Migration-Guide.md
@@ -57,7 +57,7 @@
 2. **下载新版本:**
    ```bash
    # 下载带版本号的 Release 压缩包
-   VERSION=7.2.0
+   VERSION=7.3.0
    wget "https://github.com/soulteary/webhook/releases/download/${VERSION}/webhook_${VERSION}_linux_amd64.tar.gz"
    tar -xzf "webhook_${VERSION}_linux_amd64.tar.gz"
    

--- a/docs/zh-CN/Release-Guide.md
+++ b/docs/zh-CN/Release-Guide.md
@@ -1,0 +1,123 @@
+# 发布指南
+
+本文是维护者发布 WebHook 稳定版本的操作手册。发布只能由一次不可变的语义化
+版本 Tag 推送触发。不要手工创建 GitHub Release，也不要从 Actions 页面手工
+运行 Release 工作流。
+
+## 7.3.0 发布范围
+
+7.3.0 包含 7.2.0 之后的以下变更：
+
+- 移除重复的 `webhook-config-ui` Release 二进制；统一使用唯一的
+  `webhook` 二进制和 `webhook -config-ui`；
+- 通过 `getSecret` 和 `trimSpace` 增加受约束的 Docker Secret 模板支持，
+  不开放任意文件系统读取；
+- 将示例、容器标签、完整性校验命令和迁移下载版本更新到 7.3.0；
+- 将 Release CI 限制为只接受 Tag，并把发布、证明和验证拆为可安全重试的 Job。
+
+## 发布不变量
+
+- Tag 必须是没有 `v` 前缀的 `MAJOR.MINOR.PATCH`。
+- 被打 Tag 的提交已经进入 `main`，且该提交的所有必需检查均通过。
+- 每个版本只打一次 Tag；绝不移动、删除或复用已经发布的 Tag。
+- GitHub Release 和两个镜像仓库的镜像均由 Release 工作流创建。
+- `publish` 只能执行一次；`attest`、`verify` 或 Documentation 可以独立重试，
+  不会再次运行 GoReleaser。
+
+## 发布前提
+
+准备 Tag 前必须：
+
+1. 合并本次发布的全部 PR，包括版本和文档准备 PR。
+2. 等待最终 `main` 提交上的 Tests、容器 Smoke Test、Security Scan、CodeQL、
+   Documentation 和 Benchmarks 全部通过。
+3. 确认 Actions 可以使用 Docker Hub 凭据及 GitHub 仓库、Package 权限。
+4. 本地安装 `go.mod` 指定的 Go、`requirements-docs.txt` 中的 MkDocs 依赖、
+   GitHub CLI 和 GoReleaser v2.18.0。
+
+7.3.0 选定的 `main` 提交必须同时包含 PR #177 和 PR #178。
+
+## 无误发布的准确顺序
+
+在干净的 Clone 中执行以下命令。`release-preflight.sh` 会拒绝非 `main` 分支、
+存在未提交修改、落后于远端 `main` 或已经存在同名 Tag 的情况。
+
+```bash
+git fetch origin main --tags
+git switch main
+git pull --ff-only origin main
+
+RELEASE_VERSION=7.3.0
+./scripts/release-preflight.sh "$RELEASE_VERSION"
+
+RELEASE_COMMIT="$(git rev-parse HEAD)"
+git tag -a "$RELEASE_VERSION" "$RELEASE_COMMIT" -m "Release $RELEASE_VERSION"
+git push origin "refs/tags/$RELEASE_VERSION"
+```
+
+只能推送上面这一枚 Tag。不要使用 `git push --tags`，否则可能把无关的本地 Tag
+一起发布。推送前不要创建 Draft 或空的 GitHub Release，因为该操作由 GoReleaser
+负责。
+
+Tag 推送后会按以下顺序执行：
+
+| 顺序 | Workflow/Job | 副作用 | 重试规则 |
+|---|---|---|---|
+| 1 | Release / `publish` | 测试、构建、GitHub Release、压缩包、SBOM、已签名多架构镜像 | 只执行一次 |
+| 2 | Release / `attest` | 下载已发布资产并生成 GitHub Provenance | 只重试该 Job |
+| 3 | Release / `verify` | 验证资产、Sigstore Bundle、Provenance、镜像 UID 和镜像签名 | 只重试该 Job |
+| 并行 | Documentation | 构建 `7.3.0`、更新 `latest` 并设置文档默认版本 | 独立重试 |
+
+必须等待两个工作流完成；看到 GitHub Release 已出现不代表发布已经完成。
+
+```bash
+RELEASE_RUN_ID="$(gh run list --workflow build.yml --branch "$RELEASE_VERSION" --limit 1 --json databaseId --jq '.[0].databaseId')"
+gh run watch "$RELEASE_RUN_ID" --exit-status
+
+DOCS_RUN_ID="$(gh run list --workflow docs.yml --branch "$RELEASE_VERSION" --limit 1 --json databaseId --jq '.[0].databaseId')"
+gh run watch "$DOCS_RUN_ID" --exit-status
+```
+
+## 发布后验证
+
+两个工作流均通过后执行：
+
+```bash
+gh release view "$RELEASE_VERSION" --repo soulteary/webhook \
+  --json tagName,isDraft,isPrerelease,url
+
+mkdir -p "release-$RELEASE_VERSION"
+gh release download "$RELEASE_VERSION" --repo soulteary/webhook \
+  --dir "release-$RELEASE_VERSION"
+find "release-$RELEASE_VERSION" -maxdepth 1 -type f -printf '%f\n' | sort
+
+test -z "$(find "release-$RELEASE_VERSION" -name '*webhook-config-ui*' -print -quit)"
+
+for variant in core runner extended; do
+  image="ghcr.io/soulteary/webhook:${variant}-${RELEASE_VERSION}"
+  docker pull "$image"
+  test "$(docker image inspect --format '{{ .Config.User }}' "$image")" = "65532:65532"
+  docker run --rm "$image" -version | grep "$RELEASE_VERSION"
+done
+```
+
+还需要确认 `https://soulteary.github.io/webhook/7.3.0/` 和 `latest` 文档地址均可
+正常访问。Release 工作流已经自动验证 Checksum Sigstore Bundle、GitHub
+Attestation、镜像签名及三类运行时镜像。
+
+## 失败处理
+
+不要立即点击 **Re-run all jobs**。
+
+| 失败位置 | 安全操作 |
+|---|---|
+| 准备 PR 或本地预检 | 修复分支并重新执行检查；此时还没有 Release |
+| `publish`，且 **Run GoReleaser** 尚未开始 | 重试失败的 `publish` Job |
+| `publish`，且 **Run GoReleaser** 已经开始 | 不要重试；先检查 GitHub Release 和两个镜像仓库是否存在部分不可变产物 |
+| `attest` | 重试失败 Job；已经完成的 `publish` 不会重跑 |
+| `verify` | 重试失败 Job，或只重试 `verify` |
+| Documentation | 只重试 Documentation 工作流 |
+
+如果 GoReleaser 已经开始，并且任意带版本号的 Release 资产或镜像已经存在，
+不要删除 Tag 后复用版本。保留现场，在 `main` 修复原因后发布下一个 Patch 版本
+（例如 7.3.1），避免同一个不可变版本对应不同的二进制内容。

--- a/example/lark/docker-compose.yml
+++ b/example/lark/docker-compose.yml
@@ -4,7 +4,7 @@ version: '2'
 services:
 
   webhook:
-    image: soulteary/webhook:extended-7.2.0
+    image: soulteary/webhook:extended-7.3.0
     ports:
       - 9000:9000
     environment:

--- a/example/multi-webhook/docker-compose.yml
+++ b/example/multi-webhook/docker-compose.yml
@@ -4,7 +4,7 @@ version: '2'
 services:
 
   webhook:
-    image: soulteary/webhook:runner-7.2.0
+    image: soulteary/webhook:runner-7.3.0
     ports:
       - 9000:9000
     environment:

--- a/example/owlmail/README.md
+++ b/example/owlmail/README.md
@@ -8,7 +8,7 @@ set of environment variables.
 OwlMail `v0.9.0` adds a durable local outbox, optional Redis-backed recovery,
 and replay-aware signature metadata to the webhook pipeline. The Compose demo
 pins `ghcr.io/soulteary/owlmail:0.9.0` and
-`soulteary/webhook:runner-7.2.0`, and keeps OwlMail's safe default delivery
+`soulteary/webhook:runner-7.3.0`, and keeps OwlMail's safe default delivery
 concurrency of `8` explicit.
 
 ## Run

--- a/example/owlmail/README.zh-CN.md
+++ b/example/owlmail/README.zh-CN.md
@@ -7,7 +7,7 @@
 
 OwlMail `v0.9.0` 为 Webhook 链路增加了持久本地 outbox、可选 Redis 恢复队列与
 防重放签名元数据。Compose Demo 固定使用
-`ghcr.io/soulteary/owlmail:0.9.0` 和 `soulteary/webhook:runner-7.2.0`，并显式
+`ghcr.io/soulteary/owlmail:0.9.0` 和 `soulteary/webhook:runner-7.3.0`，并显式
 保留 OwlMail 的安全默认并发值 `8`。
 
 ## 运行

--- a/example/owlmail/compose.yaml
+++ b/example/owlmail/compose.yaml
@@ -1,6 +1,6 @@
 services:
   webhook:
-    image: soulteary/webhook:runner-7.2.0
+    image: soulteary/webhook:runner-7.3.0
     ports:
       - "127.0.0.1:9000:9000"
     environment:

--- a/example/owlmail/example_test.go
+++ b/example/owlmail/example_test.go
@@ -90,7 +90,7 @@ func TestOwlMailConfigAndDocumentation(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, required := range []string{
-		"soulteary/webhook:runner-7.2.0",
+		"soulteary/webhook:runner-7.3.0",
 		"ghcr.io/soulteary/owlmail:0.9.0",
 		"127.0.0.1:9000:9000",
 		"127.0.0.1:1025:1025",

--- a/example/quickstart/compose.yaml
+++ b/example/quickstart/compose.yaml
@@ -1,6 +1,6 @@
 services:
   webhook:
-    image: ${WEBHOOK_IMAGE:-soulteary/webhook:runner-7.2.0}
+    image: ${WEBHOOK_IMAGE:-soulteary/webhook:runner-7.3.0}
     container_name: webhook-quickstart
     command:
       - -profile

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
       - Testing: en-US/Testing-Guide.md
       - Troubleshooting: en-US/Troubleshooting.md
       - Migration: en-US/Migration-Guide.md
+      - Release guide: en-US/Release-Guide.md
       - OwlMail integration: en-US/OwlMail-Integration.md
   - 中文:
       - 容器镜像: zh-CN/Container-Images.md
@@ -59,4 +60,5 @@ nav:
       - 测试: zh-CN/Testing-Guide.md
       - 故障排除: zh-CN/Troubleshooting.md
       - 迁移: zh-CN/Migration-Guide.md
+      - 发布指南: zh-CN/Release-Guide.md
       - OwlMail 集成: zh-CN/OwlMail-Integration.md

--- a/release_metadata_test.go
+++ b/release_metadata_test.go
@@ -57,6 +57,23 @@ func TestGoReleaserDoesNotPublishDuplicateConfigUIBinary(t *testing.T) {
 	}
 }
 
+func TestReleaseWorkflowIsTagOnlyAndRetrySafe(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/build.yml")
+	require.NoError(t, err)
+	workflow := string(data)
+
+	assert.NotContains(t, workflow, "workflow_dispatch:",
+		"the publishing workflow must not be manually dispatchable")
+	assert.Contains(t, workflow, "group: release-${{ github.ref }}")
+	assert.Contains(t, workflow, "cancel-in-progress: false")
+	assert.Contains(t, workflow, "github.event_name == 'push' && github.ref_type == 'tag'")
+	assert.Contains(t, workflow, "  publish:")
+	assert.Contains(t, workflow, "  attest:\n")
+	assert.Contains(t, workflow, "    needs: publish")
+	assert.Contains(t, workflow, "  verify:\n")
+	assert.Contains(t, workflow, "    needs: attest")
+}
+
 func TestGoReleaserPublishesSupplyChainMetadata(t *testing.T) {
 	data, err := os.ReadFile(".goreleaser.yaml")
 	require.NoError(t, err)

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+REPOSITORY="soulteary/webhook"
+REPOSITORY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RELEASE_VERSION="${1:-}"
+
+fail() {
+  echo "release preflight failed: $*" >&2
+  exit 1
+}
+
+for command_name in git go mkdocs goreleaser gh; do
+  command -v "$command_name" >/dev/null 2>&1 || fail "missing required command: $command_name"
+done
+gh auth status >/dev/null 2>&1 || fail "GitHub CLI is not authenticated"
+
+[[ "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || \
+  fail "usage: $0 MAJOR.MINOR.PATCH (without a v prefix)"
+
+cd "$REPOSITORY_ROOT"
+
+[[ "$(git branch --show-current)" == "main" ]] || fail "run from the main branch"
+[[ -z "$(git status --porcelain)" ]] || fail "the working tree is not clean"
+
+git fetch --prune origin main --tags
+[[ "$(git rev-parse HEAD)" == "$(git rev-parse origin/main)" ]] || \
+  fail "local main does not exactly match origin/main"
+
+if git show-ref --verify --quiet "refs/tags/$RELEASE_VERSION"; then
+  fail "local tag $RELEASE_VERSION already exists"
+fi
+
+set +e
+git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_VERSION" >/dev/null 2>&1
+remote_tag_status=$?
+set -e
+case "$remote_tag_status" in
+  0) fail "remote tag $RELEASE_VERSION already exists" ;;
+  2) ;;
+  *) fail "could not confirm that remote tag $RELEASE_VERSION is unused" ;;
+esac
+
+if gh release view "$RELEASE_VERSION" --repo "$REPOSITORY" >/dev/null 2>&1; then
+  fail "GitHub Release $RELEASE_VERSION already exists"
+fi
+
+for versioned_file in \
+  README.md \
+  docs/en-US/Container-Images.md \
+  docs/zh-CN/Container-Images.md \
+  docs/en-US/Migration-Guide.md \
+  docs/zh-CN/Migration-Guide.md \
+  example/quickstart/compose.yaml; do
+  grep -F "$RELEASE_VERSION" "$versioned_file" >/dev/null || \
+    fail "$versioned_file does not reference $RELEASE_VERSION"
+done
+
+go mod tidy
+git diff --exit-code -- go.mod go.sum
+go test -race ./...
+goreleaser check
+
+documentation_output="$(mktemp -d)"
+trap 'rm -rf "$documentation_output"' EXIT
+mkdocs build --strict --site-dir "$documentation_output"
+
+[[ -z "$(git status --porcelain)" ]] || fail "preflight changed the working tree"
+
+echo "release preflight passed for $RELEASE_VERSION at $(git rev-parse HEAD)"
+echo "next: create one annotated tag and push only refs/tags/$RELEASE_VERSION"


### PR DESCRIPTION
## Summary

- update current image, download, integrity, and runnable example references from 7.2.0 to 7.3.0 while preserving historical minimum-version notes
- add English and Chinese maintainer release guides with the exact tag-only sequence, post-release verification, and failure recovery rules
- add `scripts/release-preflight.sh` to reject dirty/stale/non-main checkouts, reused versions, invalid tags, inconsistent version docs, failing tests, invalid GoReleaser config, or broken documentation
- make Release CI push-tag-only, validate stable semantic-version tags from `main`, and serialize each tag
- split GoReleaser publishing, provenance attestation, and verification into `publish -> attest -> verify`, so post-publish checks can be retried without publishing the same version twice
- replace the release-shaped `7.2.0-test` container test marker with the version-neutral `ci-test`

## Release scope

The 7.3.0 guide records the two changes since 7.2.0:

- #177 removes the duplicate Config UI binary
- #178 adds constrained Docker Secret template support

This PR does **not** create or push the `7.3.0` tag and therefore does not trigger a release.

## Validation

- `go test . ./example/owlmail`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/build.yml .github/workflows/test.yml .github/workflows/docs.yml`
- `go run github.com/goreleaser/goreleaser/v2@v2.18.0 check`
- `mkdocs build --strict` with dependencies from `requirements-docs.txt`
- `bash -n scripts/release-preflight.sh`
- `git diff --check`

The complete local `go test ./...` run reached the existing IPv6 `[::]` HTTP tests in `internal/server`; those time out in this container environment. The changed release metadata and example tests pass, and repository CI remains the authoritative full race-test check.
