### PR TITLE
fix: bootstrap MkDocs in release preflight

### DIFF
--- a/docs/en-US/Release-Guide.md
+++ b/docs/en-US/Release-Guide.md
@@ -36,8 +36,11 @@ Before preparing a tag:
    and Benchmarks on the resulting `main` commit.
 3. Confirm the Docker Hub credentials and GitHub repository/package permissions
    are available to Actions.
-4. Install Go according to `go.mod`, MkDocs dependencies from
-   `requirements-docs.txt`, GitHub CLI, and GoReleaser v2.18.0 locally.
+4. Install Go according to `go.mod`, GitHub CLI, and GoReleaser v2.18.0
+   locally. For documentation, use either MkDocs or Python 3 with `venv`; when
+   `mkdocs` is not on `PATH`, the preflight script installs the pinned
+   `requirements-docs.txt` dependencies in a temporary virtual environment;
+   this fallback needs network access on its first run.
 
 For 7.3.0, PR #177 and PR #178 must both be present in the selected `main`
 commit.

--- a/docs/zh-CN/Release-Guide.md
+++ b/docs/zh-CN/Release-Guide.md
@@ -32,8 +32,10 @@
 2. 等待最终 `main` 提交上的 Tests、容器 Smoke Test、Security Scan、CodeQL、
    Documentation 和 Benchmarks 全部通过。
 3. 确认 Actions 可以使用 Docker Hub 凭据及 GitHub 仓库、Package 权限。
-4. 本地安装 `go.mod` 指定的 Go、`requirements-docs.txt` 中的 MkDocs 依赖、
-   GitHub CLI 和 GoReleaser v2.18.0。
+4. 本地安装 `go.mod` 指定的 Go、GitHub CLI 和 GoReleaser v2.18.0。文档构建
+   可以使用 MkDocs，或带 `venv` 的 Python 3；如果 `PATH` 中没有 `mkdocs`，
+   预检脚本会在临时虚拟环境中安装 `requirements-docs.txt` 锁定的依赖；首次
+   使用该回退路径时需要能够访问网络。
 
 7.3.0 选定的 `main` 提交必须同时包含 PR #177 和 PR #178。
 

--- a/release_metadata_test.go
+++ b/release_metadata_test.go
@@ -74,6 +74,18 @@ func TestReleaseWorkflowIsTagOnlyAndRetrySafe(t *testing.T) {
 	assert.Contains(t, workflow, "    needs: attest")
 }
 
+func TestReleasePreflightBootstrapsDocumentationTools(t *testing.T) {
+	data, err := os.ReadFile("scripts/release-preflight.sh")
+	require.NoError(t, err)
+	script := string(data)
+
+	assert.NotContains(t, script, "git go mkdocs goreleaser gh")
+	assert.Contains(t, script, "if command -v mkdocs")
+	assert.Contains(t, script, "python3 -m venv")
+	assert.Contains(t, script, "-r requirements-docs.txt")
+	assert.Contains(t, script, `"$documentation_environment/bin/mkdocs" build`)
+}
+
 func TestGoReleaserPublishesSupplyChainMetadata(t *testing.T) {
 	data, err := os.ReadFile(".goreleaser.yaml")
 	require.NoError(t, err)

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -11,7 +11,7 @@ fail() {
   exit 1
 }
 
-for command_name in git go mkdocs goreleaser gh; do
+for command_name in git go goreleaser gh; do
   command -v "$command_name" >/dev/null 2>&1 || fail "missing required command: $command_name"
 done
 gh auth status >/dev/null 2>&1 || fail "GitHub CLI is not authenticated"
@@ -63,8 +63,31 @@ go test -race ./...
 goreleaser check
 
 documentation_output="$(mktemp -d)"
-trap 'rm -rf "$documentation_output"' EXIT
-mkdocs build --strict --site-dir "$documentation_output"
+documentation_environment=""
+cleanup() {
+  if [[ -n "$documentation_environment" && -d "$documentation_environment" ]]; then
+    rm -rf -- "$documentation_environment"
+  fi
+  if [[ -d "$documentation_output" ]]; then
+    rm -rf -- "$documentation_output"
+  fi
+}
+trap cleanup EXIT
+
+if command -v mkdocs >/dev/null 2>&1; then
+  mkdocs build --strict --site-dir "$documentation_output"
+else
+  command -v python3 >/dev/null 2>&1 || \
+    fail "missing mkdocs and python3; install one of them to build documentation"
+  documentation_environment="$(mktemp -d)"
+  python3 -m venv "$documentation_environment"
+  "$documentation_environment/bin/python" -m pip install \
+    --disable-pip-version-check \
+    -r requirements-docs.txt
+  "$documentation_environment/bin/mkdocs" build \
+    --strict \
+    --site-dir "$documentation_output"
+fi
 
 [[ -z "$(git status --porcelain)" ]] || fail "preflight changed the working tree"
 


### PR DESCRIPTION
## Summary

- stop requiring a globally installed `mkdocs` command before release preflight can start
- use an existing `mkdocs` when available
- otherwise require Python 3, create a temporary virtual environment, install the pinned `requirements-docs.txt`, run the strict documentation build, and clean up automatically
- document the fallback and its first-run network requirement in English and Chinese
- add a regression test for the documentation-tool bootstrap contract

## Why

The documented 7.3.0 sequence currently stops immediately with:

```text
release preflight failed: missing required command: mkdocs
```

MkDocs is only needed for the documentation validation stage and should not require a global Python installation. This keeps the release checkout clean while preserving the strict build.

No `7.3.0` tag or GitHub Release exists, so this fix can be merged before continuing the release.

## Validation

- exercised the fallback with no global `mkdocs`: temporary venv creation, pinned dependency install, and `mkdocs build --strict` all passed
- `go test .`
- `bash -n scripts/release-preflight.sh`
- Actionlint v1.7.7 on the Release workflow
- `git diff --check`
