### PR TITLE
build: simplify releases to one command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,18 @@ jobs:
           fi
           git fetch origin main
           git merge-base --is-ancestor "${GITHUB_SHA}" origin/main
-          if gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+          if release_response="$(gh api \
+            --method GET \
+            --include \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}" \
+            2>&1)"; then
             echo "release ${GITHUB_REF_NAME} already exists; refusing to publish it again" >&2
+            exit 1
+          elif ! grep -Eq '^HTTP/[0-9.]+ 404 ' <<<"$release_response"; then
+            echo "could not confirm that release ${GITHUB_REF_NAME} is unused" >&2
+            printf '%s\n' "$release_response" >&2
             exit 1
           fi
 
@@ -210,3 +220,31 @@ jobs:
               --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
               "$image"
           done
+
+  documentation:
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements-docs.txt
+
+      - name: Install documentation dependencies
+        run: python -m pip install --disable-pip-version-check -r requirements-docs.txt
+
+      - name: Configure Git identity
+        run: git config user.name github-actions && git config user.email github-actions@github.com
+
+      - name: Deploy release documentation
+        run: mike deploy --push --update-aliases "${GITHUB_REF_NAME}" latest && mike set-default --push latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,70 @@ permissions:
   contents: read
 
 jobs:
+  preflight:
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate release ref
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "release tag must be a stable semantic version such as 7.3.0" >&2
+            exit 1
+          fi
+          git fetch origin main
+          git merge-base --is-ancestor "${GITHUB_SHA}" origin/main
+          if gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "release ${GITHUB_REF_NAME} already exists; refusing to publish it again" >&2
+            exit 1
+          fi
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Cache Go modules
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Tests
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
+          go test -race ./...
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements-docs.txt
+
+      - name: Validate documentation
+        run: |
+          python -m pip install --disable-pip-version-check -r requirements-docs.txt
+          mkdocs build --strict
+
+      - name: Validate GoReleaser configuration
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
+        with:
+          version: v2.18.0
+          args: check
+
   publish:
     if: github.event_name == 'push' && github.ref_type == 'tag'
+    needs: preflight
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -29,15 +91,6 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
-
-      - name: Validate release ref
-        run: |
-          if [[ ! "${GITHUB_REF_NAME}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "release tag must be a stable semantic version such as 7.3.0" >&2
-            exit 1
-          fi
-          git fetch origin main
-          git merge-base --is-ancestor "${GITHUB_SHA}" origin/main
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
@@ -54,12 +107,6 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-
-      - name: Tests
-        run: |
-          go mod tidy
-          git diff --exit-code -- go.mod go.sum
-          go test -race ./...
 
       - name: Login to Docker Hub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,8 +14,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "*.*.*"
     paths:
       - "docs/**"
       - "example/**"
@@ -53,7 +51,7 @@ jobs:
         run: mkdocs build --strict
 
   deploy:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref_type == 'branch'
     needs: build
     runs-on: ubuntu-latest
     permissions:
@@ -80,7 +78,3 @@ jobs:
       - name: Deploy development documentation
         if: github.ref_type == 'branch'
         run: mike deploy --push --update-aliases dev
-
-      - name: Deploy release documentation
-        if: github.ref_type == 'tag'
-        run: mike deploy --push --update-aliases "${{ github.ref_name }}" latest && mike set-default --push latest

--- a/docs/en-US/Release-Guide.md
+++ b/docs/en-US/Release-Guide.md
@@ -15,8 +15,8 @@ The 7.3.0 release includes the following changes after 7.2.0:
   `trimSpace`, without exposing arbitrary filesystem reads;
 - update examples, container tags, integrity commands, and migration downloads
   to 7.3.0;
-- make Release CI tag-only and split publishing, attestation, and verification
-  into retry-safe jobs.
+- make Release CI tag-only and split validation, publishing, attestation, and
+  verification into retry-safe jobs.
 
 ## Release invariants
 
@@ -24,8 +24,9 @@ The 7.3.0 release includes the following changes after 7.2.0:
 - The tagged commit is already on `main`, and all required checks passed on it.
 - A version is tagged once. Never move, delete, or reuse a published tag.
 - The Release workflow creates the GitHub Release and both registries' images.
-- `publish` runs once. `attest`, `verify`, or Documentation may be retried
-  independently without running GoReleaser again.
+- `preflight` performs all build checks before credentials or publishing are
+  used. `publish` runs once. `attest`, `verify`, or Documentation may be
+  retried independently without running GoReleaser again.
 
 ## Prerequisites
 
@@ -36,50 +37,42 @@ Before preparing a tag:
    and Benchmarks on the resulting `main` commit.
 3. Confirm the Docker Hub credentials and GitHub repository/package permissions
    are available to Actions.
-4. Install Go according to `go.mod`, GitHub CLI, and GoReleaser v2.18.0
-   locally. For documentation, use either MkDocs or Python 3 with `venv`; when
-   `mkdocs` is not on `PATH`, the preflight script installs the pinned
-   `requirements-docs.txt` dependencies in a temporary virtual environment;
-   this fallback needs network access on its first run.
+4. Install Git. Go, Python, MkDocs, GoReleaser, Syft, Cosign, and GitHub CLI are
+   provided by GitHub Actions and are not local release dependencies.
 
 For 7.3.0, PR #177 and PR #178 must both be present in the selected `main`
 commit.
 
 ## Exact publishing sequence
 
-Run these commands from a clean clone. `release-preflight.sh` refuses to run
-from a branch other than `main`, from a dirty or stale checkout, or when the tag
-already exists.
+From an up-to-date, clean `main` checkout, run one command:
 
 ```bash
-git fetch origin main --tags
-git switch main
-git pull --ff-only origin main
-
-RELEASE_VERSION=7.3.0
-./scripts/release-preflight.sh "$RELEASE_VERSION"
-
-RELEASE_COMMIT="$(git rev-parse HEAD)"
-git tag -a "$RELEASE_VERSION" "$RELEASE_COMMIT" -m "Release $RELEASE_VERSION"
-git push origin "refs/tags/$RELEASE_VERSION"
+./scripts/release.sh 7.3.0
 ```
 
-Push only the one tag shown above. Do not use `git push --tags`; it can publish
-an unrelated local tag. Do not create a draft or empty GitHub Release before
-the push, because GoReleaser owns that operation.
+The command runs a fast Git-only preflight, displays the exact commit, and asks
+you to type `7.3.0` before it creates and pushes one annotated tag. It refuses a
+dirty checkout, a non-`main` branch, a checkout that differs from `origin/main`,
+an invalid version, stale version references, or an existing local/remote tag.
+
+Do not create a draft or empty GitHub Release first; GoReleaser owns that
+operation. The script pushes only `refs/tags/7.3.0`, never all local tags.
 
 The tag push starts these paths:
 
 | Order | Workflow/job | Side effects | Retry rule |
 |---|---|---|---|
-| 1 | Release / `publish` | Tests, builds, GitHub Release, archives, SBOMs, signed container manifests | Run once only |
-| 2 | Release / `attest` | Downloads published assets and creates GitHub provenance | Retry this job only |
-| 3 | Release / `verify` | Verifies assets, Sigstore bundle, provenance, image UID, and image signatures | Retry this job only |
+| 1 | Release / `preflight` | Validates the tag and `main` ancestry, runs race tests, builds strict documentation, and checks GoReleaser configuration | No publishing side effects; safe to retry |
+| 2 | Release / `publish` | Builds the GitHub Release, archives, SBOMs, and signed container manifests | Run once only |
+| 3 | Release / `attest` | Downloads published assets and creates GitHub provenance | Retry this job only |
+| 4 | Release / `verify` | Verifies assets, Sigstore bundle, provenance, image UID, and image signatures | Retry this job only |
 | Parallel | Documentation | Builds `7.3.0`, updates `latest`, and sets the documentation default | Retry independently |
 
 Wait for both workflows; a visible GitHub Release is not completion by itself.
 
 ```bash
+RELEASE_VERSION=7.3.0
 RELEASE_RUN_ID="$(gh run list --workflow build.yml --branch "$RELEASE_VERSION" --limit 1 --json databaseId --jq '.[0].databaseId')"
 gh run watch "$RELEASE_RUN_ID" --exit-status
 
@@ -121,7 +114,8 @@ Do not immediately press **Re-run all jobs**.
 
 | Failure point | Safe action |
 |---|---|
-| Preparation PR or local preflight | Fix the branch and rerun checks; no release exists yet |
+| Local preflight or confirmation | Fix/update the checkout and rerun the command; no release exists yet |
+| CI `preflight` | Fix `main`, prepare a new version, and push a new tag; publishing did not start |
 | `publish`, before **Run GoReleaser** starts | Re-run the failed `publish` job |
 | `publish`, after **Run GoReleaser** starts | Do not rerun; inspect the GitHub Release and both registries for partial immutable artifacts |
 | `attest` | Re-run failed jobs; `publish` remains completed |
@@ -132,3 +126,7 @@ If GoReleaser started and any versioned release asset or image exists, do not
 delete the tag and reuse the version. Preserve the evidence, fix the cause on
 `main`, and publish the next patch version (for example, 7.3.1). This avoids
 serving different bytes under the same immutable version.
+
+If the local tag was created but the push failed, inspect it with
+`git show 7.3.0`, then retry only `git push origin refs/tags/7.3.0`. Do not rerun
+`release.sh`, because its duplicate-tag guard will stop.

--- a/docs/en-US/Release-Guide.md
+++ b/docs/en-US/Release-Guide.md
@@ -15,8 +15,8 @@ The 7.3.0 release includes the following changes after 7.2.0:
   `trimSpace`, without exposing arbitrary filesystem reads;
 - update examples, container tags, integrity commands, and migration downloads
   to 7.3.0;
-- make Release CI tag-only and split validation, publishing, attestation, and
-  verification into retry-safe jobs.
+- make Release CI tag-only and split validation, publishing, attestation,
+  verification, and release documentation into retry-safe jobs.
 
 ## Release invariants
 
@@ -25,7 +25,7 @@ The 7.3.0 release includes the following changes after 7.2.0:
 - A version is tagged once. Never move, delete, or reuse a published tag.
 - The Release workflow creates the GitHub Release and both registries' images.
 - `preflight` performs all build checks before credentials or publishing are
-  used. `publish` runs once. `attest`, `verify`, or Documentation may be
+  used. `publish` runs once. `attest`, `verify`, or `documentation` may be
   retried independently without running GoReleaser again.
 
 ## Prerequisites
@@ -67,22 +67,20 @@ The tag push starts these paths:
 | 2 | Release / `publish` | Builds the GitHub Release, archives, SBOMs, and signed container manifests | Run once only |
 | 3 | Release / `attest` | Downloads published assets and creates GitHub provenance | Retry this job only |
 | 4 | Release / `verify` | Verifies assets, Sigstore bundle, provenance, image UID, and image signatures | Retry this job only |
-| Parallel | Documentation | Builds `7.3.0`, updates `latest`, and sets the documentation default | Retry independently |
+| 5 | Release / `documentation` | Builds `7.3.0`, updates `latest`, and sets the documentation default | Retry this job only |
 
-Wait for both workflows; a visible GitHub Release is not completion by itself.
+Wait for the Release workflow; a visible GitHub Release is not completion by
+itself.
 
 ```bash
 RELEASE_VERSION=7.3.0
 RELEASE_RUN_ID="$(gh run list --workflow build.yml --branch "$RELEASE_VERSION" --limit 1 --json databaseId --jq '.[0].databaseId')"
 gh run watch "$RELEASE_RUN_ID" --exit-status
-
-DOCS_RUN_ID="$(gh run list --workflow docs.yml --branch "$RELEASE_VERSION" --limit 1 --json databaseId --jq '.[0].databaseId')"
-gh run watch "$DOCS_RUN_ID" --exit-status
 ```
 
 ## Post-release verification
 
-After both workflows pass:
+After the Release workflow passes:
 
 ```bash
 gh release view "$RELEASE_VERSION" --repo soulteary/webhook \
@@ -120,7 +118,7 @@ Do not immediately press **Re-run all jobs**.
 | `publish`, after **Run GoReleaser** starts | Do not rerun; inspect the GitHub Release and both registries for partial immutable artifacts |
 | `attest` | Re-run failed jobs; `publish` remains completed |
 | `verify` | Re-run failed jobs or the `verify` job only |
-| Documentation | Re-run only the Documentation workflow |
+| `documentation` | Re-run the failed `documentation` job only |
 
 If GoReleaser started and any versioned release asset or image exists, do not
 delete the tag and reuse the version. Preserve the evidence, fix the cause on

--- a/docs/zh-CN/Release-Guide.md
+++ b/docs/zh-CN/Release-Guide.md
@@ -13,8 +13,8 @@
 - 通过 `getSecret` 和 `trimSpace` 增加受约束的 Docker Secret 模板支持，
   不开放任意文件系统读取；
 - 将示例、容器标签、完整性校验命令和迁移下载版本更新到 7.3.0；
-- 将 Release CI 限制为只接受 Tag，并把预检、发布、证明和验证拆为可安全重试的
-  Job。
+- 将 Release CI 限制为只接受 Tag，并把预检、发布、证明、验证和文档发布拆为
+  可安全重试的 Job。
 
 ## 发布不变量
 
@@ -23,7 +23,7 @@
 - 每个版本只打一次 Tag；绝不移动、删除或复用已经发布的 Tag。
 - GitHub Release 和两个镜像仓库的镜像均由 Release 工作流创建。
 - `preflight` 在使用发布凭据或产生发布副作用前执行全部构建检查。`publish` 只能
-  执行一次；`attest`、`verify` 或 Documentation 可以独立重试，不会再次运行
+  执行一次；`attest`、`verify` 或 `documentation` 可以独立重试，不会再次运行
   GoReleaser。
 
 ## 发布前提
@@ -63,22 +63,19 @@ Tag 推送后会按以下顺序执行：
 | 2 | Release / `publish` | 构建 GitHub Release、压缩包、SBOM 和已签名多架构镜像 | 只执行一次 |
 | 3 | Release / `attest` | 下载已发布资产并生成 GitHub Provenance | 只重试该 Job |
 | 4 | Release / `verify` | 验证资产、Sigstore Bundle、Provenance、镜像 UID 和镜像签名 | 只重试该 Job |
-| 并行 | Documentation | 构建 `7.3.0`、更新 `latest` 并设置文档默认版本 | 独立重试 |
+| 5 | Release / `documentation` | 构建 `7.3.0`、更新 `latest` 并设置文档默认版本 | 只重试该 Job |
 
-必须等待两个工作流完成；看到 GitHub Release 已出现不代表发布已经完成。
+必须等待 Release 工作流完成；看到 GitHub Release 已出现不代表发布已经完成。
 
 ```bash
 RELEASE_VERSION=7.3.0
 RELEASE_RUN_ID="$(gh run list --workflow build.yml --branch "$RELEASE_VERSION" --limit 1 --json databaseId --jq '.[0].databaseId')"
 gh run watch "$RELEASE_RUN_ID" --exit-status
-
-DOCS_RUN_ID="$(gh run list --workflow docs.yml --branch "$RELEASE_VERSION" --limit 1 --json databaseId --jq '.[0].databaseId')"
-gh run watch "$DOCS_RUN_ID" --exit-status
 ```
 
 ## 发布后验证
 
-两个工作流均通过后执行：
+Release 工作流通过后执行：
 
 ```bash
 gh release view "$RELEASE_VERSION" --repo soulteary/webhook \
@@ -115,7 +112,7 @@ Attestation、镜像签名及三类运行时镜像。
 | `publish`，且 **Run GoReleaser** 已经开始 | 不要重试；先检查 GitHub Release 和两个镜像仓库是否存在部分不可变产物 |
 | `attest` | 重试失败 Job；已经完成的 `publish` 不会重跑 |
 | `verify` | 重试失败 Job，或只重试 `verify` |
-| Documentation | 只重试 Documentation 工作流 |
+| `documentation` | 只重试失败的 `documentation` Job |
 
 如果 GoReleaser 已经开始，并且任意带版本号的 Release 资产或镜像已经存在，
 不要删除 Tag 后复用版本。保留现场，在 `main` 修复原因后发布下一个 Patch 版本

--- a/docs/zh-CN/Release-Guide.md
+++ b/docs/zh-CN/Release-Guide.md
@@ -13,7 +13,8 @@
 - 通过 `getSecret` 和 `trimSpace` 增加受约束的 Docker Secret 模板支持，
   不开放任意文件系统读取；
 - 将示例、容器标签、完整性校验命令和迁移下载版本更新到 7.3.0；
-- 将 Release CI 限制为只接受 Tag，并把发布、证明和验证拆为可安全重试的 Job。
+- 将 Release CI 限制为只接受 Tag，并把预检、发布、证明和验证拆为可安全重试的
+  Job。
 
 ## 发布不变量
 
@@ -21,8 +22,9 @@
 - 被打 Tag 的提交已经进入 `main`，且该提交的所有必需检查均通过。
 - 每个版本只打一次 Tag；绝不移动、删除或复用已经发布的 Tag。
 - GitHub Release 和两个镜像仓库的镜像均由 Release 工作流创建。
-- `publish` 只能执行一次；`attest`、`verify` 或 Documentation 可以独立重试，
-  不会再次运行 GoReleaser。
+- `preflight` 在使用发布凭据或产生发布副作用前执行全部构建检查。`publish` 只能
+  执行一次；`attest`、`verify` 或 Documentation 可以独立重试，不会再次运行
+  GoReleaser。
 
 ## 发布前提
 
@@ -32,47 +34,41 @@
 2. 等待最终 `main` 提交上的 Tests、容器 Smoke Test、Security Scan、CodeQL、
    Documentation 和 Benchmarks 全部通过。
 3. 确认 Actions 可以使用 Docker Hub 凭据及 GitHub 仓库、Package 权限。
-4. 本地安装 `go.mod` 指定的 Go、GitHub CLI 和 GoReleaser v2.18.0。文档构建
-   可以使用 MkDocs，或带 `venv` 的 Python 3；如果 `PATH` 中没有 `mkdocs`，
-   预检脚本会在临时虚拟环境中安装 `requirements-docs.txt` 锁定的依赖；首次
-   使用该回退路径时需要能够访问网络。
+4. 本地只需要安装 Git。Go、Python、MkDocs、GoReleaser、Syft、Cosign 和
+   GitHub CLI 均由 GitHub Actions 提供，不再是本地发布依赖。
 
 7.3.0 选定的 `main` 提交必须同时包含 PR #177 和 PR #178。
 
 ## 无误发布的准确顺序
 
-在干净的 Clone 中执行以下命令。`release-preflight.sh` 会拒绝非 `main` 分支、
-存在未提交修改、落后于远端 `main` 或已经存在同名 Tag 的情况。
+在已经同步、工作区干净的 `main` 中只执行一条命令：
 
 ```bash
-git fetch origin main --tags
-git switch main
-git pull --ff-only origin main
-
-RELEASE_VERSION=7.3.0
-./scripts/release-preflight.sh "$RELEASE_VERSION"
-
-RELEASE_COMMIT="$(git rev-parse HEAD)"
-git tag -a "$RELEASE_VERSION" "$RELEASE_COMMIT" -m "Release $RELEASE_VERSION"
-git push origin "refs/tags/$RELEASE_VERSION"
+./scripts/release.sh 7.3.0
 ```
 
-只能推送上面这一枚 Tag。不要使用 `git push --tags`，否则可能把无关的本地 Tag
-一起发布。推送前不要创建 Draft 或空的 GitHub Release，因为该操作由 GoReleaser
-负责。
+该命令先执行快速、只依赖 Git 的本地预检，显示准确的提交 SHA，然后要求输入
+`7.3.0` 确认，最后创建并推送一枚 Annotated Tag。非 `main`、工作区不干净、
+本地与 `origin/main` 不一致、版本格式错误、文档版本未更新或同名 Tag 已存在时
+都会停止。
+
+推送前不要创建 Draft 或空的 GitHub Release，因为该操作由 GoReleaser 负责。
+脚本只会推送 `refs/tags/7.3.0`，不会批量推送其他本地 Tag。
 
 Tag 推送后会按以下顺序执行：
 
 | 顺序 | Workflow/Job | 副作用 | 重试规则 |
 |---|---|---|---|
-| 1 | Release / `publish` | 测试、构建、GitHub Release、压缩包、SBOM、已签名多架构镜像 | 只执行一次 |
-| 2 | Release / `attest` | 下载已发布资产并生成 GitHub Provenance | 只重试该 Job |
-| 3 | Release / `verify` | 验证资产、Sigstore Bundle、Provenance、镜像 UID 和镜像签名 | 只重试该 Job |
+| 1 | Release / `preflight` | 验证 Tag 和 `main` 祖先关系，执行 Race Test、严格文档构建和 GoReleaser 配置检查 | 没有发布副作用，可安全重试 |
+| 2 | Release / `publish` | 构建 GitHub Release、压缩包、SBOM 和已签名多架构镜像 | 只执行一次 |
+| 3 | Release / `attest` | 下载已发布资产并生成 GitHub Provenance | 只重试该 Job |
+| 4 | Release / `verify` | 验证资产、Sigstore Bundle、Provenance、镜像 UID 和镜像签名 | 只重试该 Job |
 | 并行 | Documentation | 构建 `7.3.0`、更新 `latest` 并设置文档默认版本 | 独立重试 |
 
 必须等待两个工作流完成；看到 GitHub Release 已出现不代表发布已经完成。
 
 ```bash
+RELEASE_VERSION=7.3.0
 RELEASE_RUN_ID="$(gh run list --workflow build.yml --branch "$RELEASE_VERSION" --limit 1 --json databaseId --jq '.[0].databaseId')"
 gh run watch "$RELEASE_RUN_ID" --exit-status
 
@@ -113,7 +109,8 @@ Attestation、镜像签名及三类运行时镜像。
 
 | 失败位置 | 安全操作 |
 |---|---|
-| 准备 PR 或本地预检 | 修复分支并重新执行检查；此时还没有 Release |
+| 本地预检或确认 | 修复或更新工作区后重新运行命令；此时还没有 Release |
+| CI `preflight` | 修复 `main`、准备新版本并推送新 Tag；此时尚未开始发布 |
 | `publish`，且 **Run GoReleaser** 尚未开始 | 重试失败的 `publish` Job |
 | `publish`，且 **Run GoReleaser** 已经开始 | 不要重试；先检查 GitHub Release 和两个镜像仓库是否存在部分不可变产物 |
 | `attest` | 重试失败 Job；已经完成的 `publish` 不会重跑 |
@@ -123,3 +120,7 @@ Attestation、镜像签名及三类运行时镜像。
 如果 GoReleaser 已经开始，并且任意带版本号的 Release 资产或镜像已经存在，
 不要删除 Tag 后复用版本。保留现场，在 `main` 修复原因后发布下一个 Patch 版本
 （例如 7.3.1），避免同一个不可变版本对应不同的二进制内容。
+
+如果本地 Tag 已创建但推送失败，先用 `git show 7.3.0` 检查，再只重试
+`git push origin refs/tags/7.3.0`。不要重新运行 `release.sh`，它会被重复 Tag
+保护主动终止。

--- a/release_metadata_test.go
+++ b/release_metadata_test.go
@@ -67,23 +67,39 @@ func TestReleaseWorkflowIsTagOnlyAndRetrySafe(t *testing.T) {
 	assert.Contains(t, workflow, "group: release-${{ github.ref }}")
 	assert.Contains(t, workflow, "cancel-in-progress: false")
 	assert.Contains(t, workflow, "github.event_name == 'push' && github.ref_type == 'tag'")
+	assert.Contains(t, workflow, "  preflight:")
+	assert.Contains(t, workflow, `gh release view "${GITHUB_REF_NAME}"`)
 	assert.Contains(t, workflow, "  publish:")
+	assert.Contains(t, workflow, "    needs: preflight")
 	assert.Contains(t, workflow, "  attest:\n")
 	assert.Contains(t, workflow, "    needs: publish")
 	assert.Contains(t, workflow, "  verify:\n")
 	assert.Contains(t, workflow, "    needs: attest")
 }
 
-func TestReleasePreflightBootstrapsDocumentationTools(t *testing.T) {
+func TestReleasePreflightHasNoBuildToolDependencies(t *testing.T) {
 	data, err := os.ReadFile("scripts/release-preflight.sh")
 	require.NoError(t, err)
 	script := string(data)
 
-	assert.NotContains(t, script, "git go mkdocs goreleaser gh")
-	assert.Contains(t, script, "if command -v mkdocs")
-	assert.Contains(t, script, "python3 -m venv")
-	assert.Contains(t, script, "-r requirements-docs.txt")
-	assert.Contains(t, script, `"$documentation_environment/bin/mkdocs" build`)
+	for _, command := range []string{"go test", "goreleaser", "mkdocs", "python3", "gh release"} {
+		assert.NotContains(t, script, command)
+	}
+	assert.Contains(t, script, "command -v git")
+	assert.Contains(t, script, "git fetch --prune origin main --tags")
+	assert.Contains(t, script, "git ls-remote --exit-code --tags")
+}
+
+func TestReleaseCommandPushesOnlyOneConfirmedTag(t *testing.T) {
+	data, err := os.ReadFile("scripts/release.sh")
+	require.NoError(t, err)
+	script := string(data)
+
+	assert.Contains(t, script, "scripts/release-preflight.sh")
+	assert.Contains(t, script, `[[ "$confirmation" == "$RELEASE_VERSION" ]]`)
+	assert.Contains(t, script, `git tag -a "$RELEASE_VERSION"`)
+	assert.Contains(t, script, `git push origin "refs/tags/$RELEASE_VERSION"`)
+	assert.NotContains(t, script, "git push --tags")
 }
 
 func TestGoReleaserPublishesSupplyChainMetadata(t *testing.T) {

--- a/release_metadata_test.go
+++ b/release_metadata_test.go
@@ -68,13 +68,26 @@ func TestReleaseWorkflowIsTagOnlyAndRetrySafe(t *testing.T) {
 	assert.Contains(t, workflow, "cancel-in-progress: false")
 	assert.Contains(t, workflow, "github.event_name == 'push' && github.ref_type == 'tag'")
 	assert.Contains(t, workflow, "  preflight:")
-	assert.Contains(t, workflow, `gh release view "${GITHUB_REF_NAME}"`)
+	assert.Contains(t, workflow, `"/repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}"`)
+	assert.Contains(t, workflow, `grep -Eq '^HTTP/[0-9.]+ 404 '`)
 	assert.Contains(t, workflow, "  publish:")
 	assert.Contains(t, workflow, "    needs: preflight")
 	assert.Contains(t, workflow, "  attest:\n")
 	assert.Contains(t, workflow, "    needs: publish")
 	assert.Contains(t, workflow, "  verify:\n")
 	assert.Contains(t, workflow, "    needs: attest")
+	assert.Contains(t, workflow, "  documentation:\n")
+	assert.Contains(t, workflow, "    needs: verify")
+}
+
+func TestReleaseDocumentationIsGatedByVerification(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/docs.yml")
+	require.NoError(t, err)
+	workflow := string(data)
+
+	assert.NotContains(t, workflow, "\n    tags:\n",
+		"the standalone documentation workflow must not run for release tags")
+	assert.NotContains(t, workflow, "Deploy release documentation")
 }
 
 func TestReleasePreflightHasNoBuildToolDependencies(t *testing.T) {
@@ -99,6 +112,7 @@ func TestReleaseCommandPushesOnlyOneConfirmedTag(t *testing.T) {
 	assert.Contains(t, script, `[[ "$confirmation" == "$RELEASE_VERSION" ]]`)
 	assert.Contains(t, script, `git tag -a "$RELEASE_VERSION"`)
 	assert.Contains(t, script, `git push origin "refs/tags/$RELEASE_VERSION"`)
+	assert.Contains(t, script, "preflight -> publish -> attest -> verify -> documentation")
 	assert.NotContains(t, script, "git push --tags")
 }
 

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -2,7 +2,6 @@
 
 set -Eeuo pipefail
 
-REPOSITORY="soulteary/webhook"
 REPOSITORY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 RELEASE_VERSION="${1:-}"
 
@@ -11,10 +10,7 @@ fail() {
   exit 1
 }
 
-for command_name in git go goreleaser gh; do
-  command -v "$command_name" >/dev/null 2>&1 || fail "missing required command: $command_name"
-done
-gh auth status >/dev/null 2>&1 || fail "GitHub CLI is not authenticated"
+command -v git >/dev/null 2>&1 || fail "missing required command: git"
 
 [[ "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || \
   fail "usage: $0 MAJOR.MINOR.PATCH (without a v prefix)"
@@ -42,10 +38,6 @@ case "$remote_tag_status" in
   *) fail "could not confirm that remote tag $RELEASE_VERSION is unused" ;;
 esac
 
-if gh release view "$RELEASE_VERSION" --repo "$REPOSITORY" >/dev/null 2>&1; then
-  fail "GitHub Release $RELEASE_VERSION already exists"
-fi
-
 for versioned_file in \
   README.md \
   docs/en-US/Container-Images.md \
@@ -57,39 +49,5 @@ for versioned_file in \
     fail "$versioned_file does not reference $RELEASE_VERSION"
 done
 
-go mod tidy
-git diff --exit-code -- go.mod go.sum
-go test -race ./...
-goreleaser check
-
-documentation_output="$(mktemp -d)"
-documentation_environment=""
-cleanup() {
-  if [[ -n "$documentation_environment" && -d "$documentation_environment" ]]; then
-    rm -rf -- "$documentation_environment"
-  fi
-  if [[ -d "$documentation_output" ]]; then
-    rm -rf -- "$documentation_output"
-  fi
-}
-trap cleanup EXIT
-
-if command -v mkdocs >/dev/null 2>&1; then
-  mkdocs build --strict --site-dir "$documentation_output"
-else
-  command -v python3 >/dev/null 2>&1 || \
-    fail "missing mkdocs and python3; install one of them to build documentation"
-  documentation_environment="$(mktemp -d)"
-  python3 -m venv "$documentation_environment"
-  "$documentation_environment/bin/python" -m pip install \
-    --disable-pip-version-check \
-    -r requirements-docs.txt
-  "$documentation_environment/bin/mkdocs" build \
-    --strict \
-    --site-dir "$documentation_output"
-fi
-
-[[ -z "$(git status --porcelain)" ]] || fail "preflight changed the working tree"
-
 echo "release preflight passed for $RELEASE_VERSION at $(git rev-parse HEAD)"
-echo "next: create one annotated tag and push only refs/tags/$RELEASE_VERSION"
+echo "build, test, documentation, and GoReleaser checks will run in Release CI before publishing"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -19,7 +19,7 @@ cd "$REPOSITORY_ROOT"
 RELEASE_COMMIT="$(git rev-parse HEAD)"
 echo
 echo "Ready to release $RELEASE_VERSION from $RELEASE_COMMIT"
-echo "Release CI will run preflight -> publish -> attest -> verify"
+echo "Release CI will run preflight -> publish -> attest -> verify -> documentation"
 printf "Type %s to create and push the release tag: " "$RELEASE_VERSION"
 read -r confirmation
 [[ "$confirmation" == "$RELEASE_VERSION" ]] || fail "confirmation did not match; nothing was published"
@@ -35,5 +35,4 @@ fi
 
 echo
 echo "Tag $RELEASE_VERSION was pushed successfully."
-echo "Release: https://github.com/soulteary/webhook/actions/workflows/build.yml"
-echo "Documentation: https://github.com/soulteary/webhook/actions/workflows/docs.yml"
+echo "Workflow: https://github.com/soulteary/webhook/actions/workflows/build.yml"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+REPOSITORY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RELEASE_VERSION="${1:-}"
+
+fail() {
+  echo "release failed: $*" >&2
+  exit 1
+}
+
+[[ "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || \
+  fail "usage: $0 MAJOR.MINOR.PATCH (without a v prefix)"
+
+cd "$REPOSITORY_ROOT"
+"$REPOSITORY_ROOT/scripts/release-preflight.sh" "$RELEASE_VERSION"
+
+RELEASE_COMMIT="$(git rev-parse HEAD)"
+echo
+echo "Ready to release $RELEASE_VERSION from $RELEASE_COMMIT"
+echo "Release CI will run preflight -> publish -> attest -> verify"
+printf "Type %s to create and push the release tag: " "$RELEASE_VERSION"
+read -r confirmation
+[[ "$confirmation" == "$RELEASE_VERSION" ]] || fail "confirmation did not match; nothing was published"
+
+git tag -a "$RELEASE_VERSION" "$RELEASE_COMMIT" -m "Release $RELEASE_VERSION"
+if ! git push origin "refs/tags/$RELEASE_VERSION"; then
+  echo "the annotated tag exists locally but was not published" >&2
+  echo "inspect it with: git show $RELEASE_VERSION" >&2
+  echo "after resolving the connection, retry only:" >&2
+  echo "git push origin refs/tags/$RELEASE_VERSION" >&2
+  exit 1
+fi
+
+echo
+echo "Tag $RELEASE_VERSION was pushed successfully."
+echo "Release: https://github.com/soulteary/webhook/actions/workflows/build.yml"
+echo "Documentation: https://github.com/soulteary/webhook/actions/workflows/docs.yml"


### PR DESCRIPTION
## Summary

- add `scripts/release.sh` so a maintainer publishes with one command: `./scripts/release.sh 7.3.0`
- keep local validation Git-only: clean `main`, exact `origin/main`, unused semantic-version tag, and current version references
- remove local Go, GoReleaser, MkDocs, Python, and GitHub CLI requirements
- move race tests, strict documentation build, and GoReleaser v2.18.0 configuration validation into a side-effect-free Release CI `preflight` job
- require `preflight` to pass before registry login or GoReleaser publishing
- retain the retry-safe `publish -> attest -> verify` boundary and refuse to publish over an existing GitHub Release
- require the maintainer to type the exact version before creating and pushing only that annotated tag
- document the one-command path, CI order, retry boundaries, and local tag push recovery in English and Chinese

## Why

The previous local preflight stopped successively when `mkdocs` and then `goreleaser` were not installed. Those build tools are already pinned by Actions and should not be workstation release dependencies.

## New release command

```bash
./scripts/release.sh 7.3.0
```

The script does not create a GitHub Release itself. It pushes exactly `refs/tags/7.3.0`; the tag-only workflow owns all build and publishing side effects.

No `7.3.0` tag or Release is created by this PR.

## Validation

- end-to-end temporary Git remote test: incorrect confirmation created no tag; correct confirmation created and pushed only `7.3.0`; an unrelated local tag was not pushed
- `go test .`
- Actionlint v1.7.7
- GoReleaser v2.18.0 `check`
- `mkdocs build --strict`
- `bash -n scripts/release-preflight.sh scripts/release.sh`
- `git diff --check`
