### PR TITLE
fix(ratelimit): guard the hook path against a non-positive Redis limit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/soulteary/webhook
 go 1.27.0
 
 require (
+	github.com/alicebob/miniredis/v2 v2.36.1
 	github.com/clbanning/mxj/v2 v2.7.0
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gofiber/fiber/v3 v3.5.0
@@ -57,6 +58,7 @@ require (
 	github.com/tinylib/msgp v1.6.4 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.74.0 // indirect
+	github.com/yuin/gopher-lua v1.1.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.46.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.46.0 // indirect

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -17,6 +17,13 @@ import (
 	"golang.org/x/time/rate"
 )
 
+// defaultRedisWindowLimit 是 Redis 限流在配置值非正时使用的兜底额度
+// （每分钟 6000 请求）。
+//
+// redis-kit v1.6.0 起，非正的 limit 表示"一律拒绝"，而不再是放行每个窗口的
+// 第一个请求，因此每条 Redis 限流路径都必须先兜底再调用。
+const defaultRedisWindowLimit = 100 * 60
+
 // RateLimiter 提供基于 IP 和基于 hook 的限流功能
 // 支持内存限流（默认）和 Redis 分布式限流
 type RateLimiter struct {
@@ -303,7 +310,7 @@ func (rl *RateLimiter) Middleware(next http.Handler) http.Handler {
 			globalKey := "global"
 			globalLimit := rl.config.RPS * rl.config.WindowSeconds
 			if globalLimit <= 0 {
-				globalLimit = 100 * 60 // 默认每分钟 6000 请求
+				globalLimit = defaultRedisWindowLimit
 			}
 
 			allowed, _, retryAfter := rl.checkRedisLimit(r.Context(), globalKey, globalLimit)
@@ -318,7 +325,7 @@ func (rl *RateLimiter) Middleware(next http.Handler) http.Handler {
 			ipKey := "ip:" + ip
 			ipLimit := rl.config.RPS * rl.config.WindowSeconds
 			if ipLimit <= 0 {
-				ipLimit = 100 * 60 // 默认每分钟 6000 请求
+				ipLimit = defaultRedisWindowLimit
 			}
 
 			allowed, remaining, retryAfter := rl.checkRedisLimit(r.Context(), ipKey, ipLimit)
@@ -386,6 +393,14 @@ func (rl *RateLimiter) HookMiddleware(rps int, burst int) func(next http.Handler
 						windowSeconds = 60
 					}
 					hookLimit := rps * windowSeconds
+					// Same guard as the global and per-IP paths above.
+					// redis-kit v1.6.0 made a non-positive limit mean "allow
+					// nothing" -- it used to let the first request of each
+					// window through -- so an unguarded rps of 0 here would
+					// 429 every request to the hook rather than not limit it.
+					if hookLimit <= 0 {
+						hookLimit = defaultRedisWindowLimit
+					}
 
 					allowed, remaining, retryAfter := rl.checkRedisLimit(r.Context(), hookKey, hookLimit)
 					if !allowed {

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -17,12 +17,16 @@ import (
 	"golang.org/x/time/rate"
 )
 
-// defaultRedisWindowLimit 是 Redis 限流在配置值非正时使用的兜底额度
-// （每分钟 6000 请求）。
-//
-// redis-kit v1.6.0 起，非正的 limit 表示"一律拒绝"，而不再是放行每个窗口的
-// 第一个请求，因此每条 Redis 限流路径都必须先兜底再调用。
-const defaultRedisWindowLimit = 100 * 60
+const (
+	// defaultRateLimitWindowSeconds 是 WindowSeconds 未配置时使用的窗口长度。
+	defaultRateLimitWindowSeconds = 60
+
+	// defaultFallbackRPS 是配置额度非正时兜底使用的速率（每秒请求数）。
+	//
+	// redis-kit v1.6.0 起，非正的 limit 表示"一律拒绝"，而不再是放行每个窗口
+	// 的第一个请求，因此每条 Redis 限流路径都必须先兜底再调用。
+	defaultFallbackRPS = 100
+)
 
 // RateLimiter 提供基于 IP 和基于 hook 的限流功能
 // 支持内存限流（默认）和 Redis 分布式限流
@@ -205,12 +209,26 @@ func (rl *RateLimiter) getHookLimiter(hookID string, rps int, burst int) *rate.L
 	return limiter
 }
 
+// windowSeconds 返回归一化后的限流窗口长度（秒）。
+func (rl *RateLimiter) windowSeconds() int {
+	if rl.config.WindowSeconds <= 0 {
+		return defaultRateLimitWindowSeconds
+	}
+	return rl.config.WindowSeconds
+}
+
+// fallbackRedisLimit 返回 defaultFallbackRPS 在当前窗口下对应的请求数。
+//
+// checkRedisLimit 是按窗口而非按秒计额度的，所以兜底值必须跟着窗口一起换算：
+// 固定成 6000 的话，窗口配成 3600 秒就变成每小时 6000 次，配成 1 秒就变成每秒
+// 6000 次。
+func (rl *RateLimiter) fallbackRedisLimit() int {
+	return defaultFallbackRPS * rl.windowSeconds()
+}
+
 // checkRedisLimit 使用 Redis 检查限流
 func (rl *RateLimiter) checkRedisLimit(ctx context.Context, key string, limit int) (bool, int, time.Duration) {
-	window := time.Duration(rl.config.WindowSeconds) * time.Second
-	if window == 0 {
-		window = 60 * time.Second // 默认 60 秒窗口
-	}
+	window := time.Duration(rl.windowSeconds()) * time.Second
 
 	allowed, remaining, resetTime, err := rl.redisLimiter.CheckLimit(ctx, key, limit, window)
 	if err != nil {
@@ -310,7 +328,7 @@ func (rl *RateLimiter) Middleware(next http.Handler) http.Handler {
 			globalKey := "global"
 			globalLimit := rl.config.RPS * rl.config.WindowSeconds
 			if globalLimit <= 0 {
-				globalLimit = defaultRedisWindowLimit
+				globalLimit = rl.fallbackRedisLimit()
 			}
 
 			allowed, _, retryAfter := rl.checkRedisLimit(r.Context(), globalKey, globalLimit)
@@ -325,7 +343,7 @@ func (rl *RateLimiter) Middleware(next http.Handler) http.Handler {
 			ipKey := "ip:" + ip
 			ipLimit := rl.config.RPS * rl.config.WindowSeconds
 			if ipLimit <= 0 {
-				ipLimit = defaultRedisWindowLimit
+				ipLimit = rl.fallbackRedisLimit()
 			}
 
 			allowed, remaining, retryAfter := rl.checkRedisLimit(r.Context(), ipKey, ipLimit)
@@ -388,18 +406,14 @@ func (rl *RateLimiter) HookMiddleware(rps int, burst int) func(next http.Handler
 					// 使用 Redis 分布式限流
 					hookKey := "hook:" + hookID
 					// 计算时间窗口内允许的请求数
-					windowSeconds := rl.config.WindowSeconds
-					if windowSeconds <= 0 {
-						windowSeconds = 60
-					}
-					hookLimit := rps * windowSeconds
+					hookLimit := rps * rl.windowSeconds()
 					// Same guard as the global and per-IP paths above.
 					// redis-kit v1.6.0 made a non-positive limit mean "allow
 					// nothing" -- it used to let the first request of each
 					// window through -- so an unguarded rps of 0 here would
 					// 429 every request to the hook rather than not limit it.
 					if hookLimit <= 0 {
-						hookLimit = defaultRedisWindowLimit
+						hookLimit = rl.fallbackRedisLimit()
 					}
 
 					allowed, remaining, retryAfter := rl.checkRedisLimit(r.Context(), hookKey, hookLimit)

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -642,4 +643,39 @@ func TestRateLimiter_HookMiddleware_WithConfig(t *testing.T) {
 	handler.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestHookMiddleware_NonPositiveRPSDoesNotBlockEverything pins the guard on the
+// Redis hook path.
+//
+// redis-kit v1.6.0 changed a non-positive limit from "let the first request of
+// each window through" to "allow nothing". The global and per-IP paths already
+// substituted a default for a non-positive limit; the hook path did not, so an
+// rps of 0 turned into a hard 429 on every request instead of an unconfigured
+// limit.
+func TestHookMiddleware_NonPositiveRPSDoesNotBlockEverything(t *testing.T) {
+	mr := miniredis.RunT(t)
+
+	rl := NewRateLimiterWithRedis(true, 100, 10, mr.Addr(), "", 0, "test:", 60)
+	if rl == nil {
+		t.Fatal("NewRateLimiterWithRedis returned nil")
+	}
+	t.Cleanup(func() { _ = rl.Close() })
+	if !rl.IsRedisEnabled() {
+		t.Fatal("expected the Redis-backed limiter to be enabled")
+	}
+
+	handler := rl.HookMiddleware(0, 0)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for i := range 3 {
+		req := httptest.NewRequest(http.MethodPost, "/hooks/some-hook", nil)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("request %d: got %d, want %d — a non-positive rps must not reject every request",
+				i+1, rr.Code, http.StatusOK)
+		}
+	}
 }

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -679,3 +679,29 @@ func TestHookMiddleware_NonPositiveRPSDoesNotBlockEverything(t *testing.T) {
 		}
 	}
 }
+
+// TestFallbackRedisLimit_ScalesWithWindow pins the fallback to a rate rather
+// than a fixed request count.
+//
+// checkRedisLimit charges the limit against the configured window, so a fixed
+// 6000 would mean 6000 per hour on a 3600s window and 6000 per second on a 1s
+// one. The fallback has to be computed from the same window it is spent over.
+func TestFallbackRedisLimit_ScalesWithWindow(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		windowSeconds int
+		wantWindow    int
+		wantLimit     int
+	}{
+		{"unset falls back to 60s", 0, 60, defaultFallbackRPS * 60},
+		{"negative falls back to 60s", -1, 60, defaultFallbackRPS * 60},
+		{"one second window", 1, 1, defaultFallbackRPS * 1},
+		{"one hour window", 3600, 3600, defaultFallbackRPS * 3600},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rl := &RateLimiter{config: RateLimitConfig{WindowSeconds: tc.windowSeconds}}
+			assert.Equal(t, tc.wantWindow, rl.windowSeconds())
+			assert.Equal(t, tc.wantLimit, rl.fallbackRedisLimit())
+		})
+	}
+}


### PR DESCRIPTION
Follow-up to #182, from auditing what else the kit upgrades changed.

## 1. The hook path had no guard against a non-positive limit

redis-kit v1.6.0 changed what a non-positive limit means to `CheckLimit`. It used to fall into the Lua script's "no counter yet" branch and let the first request of every window through; it now means **"allow nothing"** and rejects outright:

```go
// A non-positive limit means "allow nothing". Without this check the Lua
// script takes its "no counter yet" branch and lets the first request of
// every window through, so limit=0 admitted traffic instead of blocking it.
if limit <= 0 {
    return false, 0, time.Now().Add(window), nil
}
```

`internal/middleware/ratelimit.go` has three Redis paths. The global and per-IP ones already substituted a default; the hook path did not, so `HookMiddleware(0, ...)` went from leaving that hook effectively unlimited to answering **429 on every request** to it.

**Scope:** `HookMiddleware` is not called anywhere outside tests today, so nothing is currently broken. I'm fixing it because the dependency bump is what set the trap, and the fix is the guard its two sibling paths already have.

## 2. The fallback was a fixed count, not a rate

Caught by Codex review on the first commit, and it applied to all three paths rather than just the new one.

`checkRedisLimit` charges its limit against `config.WindowSeconds`, so the shared `100 * 60` literal was not a fixed rate: it meant 6000 per **hour** on a 3600s window and 6000 per **second** on a 1s one. The fallback is now computed from the same window it is spent over:

```go
func (rl *RateLimiter) fallbackRedisLimit() int {
	return defaultFallbackRPS * rl.windowSeconds()
}
```

so it stays 100 rps whatever `WindowSeconds` is set to, and the three paths visibly share one definition instead of repeating a magic number.

`windowSeconds()` normalizes `<= 0` rather than `== 0`. The previous check in `checkRedisLimit` was `if window == 0`, so a **negative** `WindowSeconds` produced a negative duration; `CheckLimit` rejects a non-positive window with an error, and this function's error path allows the request — meaning that configuration silently disabled Redis rate limiting altogether.

## Testing

`TestHookMiddleware_NonPositiveRPSDoesNotBlockEverything` drives a Redis-backed limiter against miniredis (already in `go.sum`; now a direct test dependency) and asserts `rps = 0` does not reject. Verified it catches the bug — with the guard removed it fails on the very first request:

```
--- FAIL: TestHookMiddleware_NonPositiveRPSDoesNotBlockEverything
    ratelimit_test.go:677: request 1: got 429, want 200 — a non-positive rps must not reject every request
```

`TestFallbackRedisLimit_ScalesWithWindow` pins the rate across unset / negative / 1s / 3600s windows.

`gofmt -s -l`, `go vet ./...`, `go test ./...` and `go test -race ./internal/middleware/` are all clean. The only failures in the full run are the three pre-existing root-permission ones (`TestSetupLogger_ErrorHandling`, `TestSetupLogger_ErrorInLogQueue`, `TestValidate_LogPath/non-writable_directory`), which fail on untouched `main` too and pass in CI.

## What else the audit covered

I diffed all 18 upgraded kits and checked each documented behavior change against this repo. Nothing else in webhook needs a change — `secure-kit`'s new Argon2 panic (no Argon2 use here), `metrics-kit`'s path-normalization default (the HTTP middleware isn't used), and `middleware-kit`'s trusted-proxy fixes (this repo uses the constructor, which was never affected by the struct-literal bug) are all either inert or already handled in #182.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyL8gxy7V6FcqYzauUosMX